### PR TITLE
MM-403: Allow config determination from env var

### DIFF
--- a/lib/jsonmerger.js
+++ b/lib/jsonmerger.js
@@ -14,7 +14,8 @@ module.exports = function jsonMerger(files, options) {
       wildcard: '*',
       strategy: defaultStrategy,
       preprocess: defaultPreProcess,
-      deleteNullValues: true
+      deleteNullValues: true,
+      stageEnv: 'NODE_ENV'
     });
     mergeFiles();
     addHelperMethods();
@@ -53,7 +54,13 @@ module.exports = function jsonMerger(files, options) {
 
       // return false when hostname is matched; short-circuiting further
       // iteration
-      return !_.includes(stage.hosts || [], hostname);
+      if (!_.isUndefined(stage.env) && stage.env === process.env[options.stageEnv]) {
+        return false;
+      }
+      if (_.includes(stage.hosts || [], hostname)) {
+        return false;
+      }
+      return true;
     });
     return merged;
   }
@@ -182,7 +189,7 @@ module.exports = function jsonMerger(files, options) {
   }
 
   /*
-   * These `wrap` and `unwrap` helper methods are neede because `_.merge`
+   * These `wrap` and `unwrap` helper methods are needed because `_.merge`
    * doesn't call the strategy callback on the root object to be merged, only
    * on its properties. This way, it is possible to use strategy directives
    * everywhere.


### PR DESCRIPTION
### Ticket
Link to ticket: https://enrise.atlassian.net/browse/MM-403

### What has been done
- Apart from hostname, environment-specific configs can now also be applied using an environment variable set on the host (defaults to `NODE_ENV`)

### How to test
- See unit tests, or do a manual config merge while having `NODE_ENV` set.