### PR TITLE
TC-1020: Keep strategy directive around long enough for proper merge

### DIFF
--- a/lib/jsonmerger.js
+++ b/lib/jsonmerger.js
@@ -4,7 +4,8 @@ module.exports = function jsonMerger(files, options) {
 
   const os = require('os');
   const _ = require('lodash');
-  const traverse = require('traverse');
+  const _fp = require('lodash/fp');
+  // const traverse = require('traverse');
 
   const dJSON = require('djson');
 
@@ -69,7 +70,7 @@ module.exports = function jsonMerger(files, options) {
   // Returning `undefined` means merging is performed at the discretion of
   // `_.merge`.
   function defaultStrategy(a, b) {
-    if (!_.isPlainObject(b)) {
+    if (!_fp.isPlainObject(b)) {
       // Cannot read a directive from this so just continue to merge natively
       return undefined;
     }
@@ -77,7 +78,37 @@ module.exports = function jsonMerger(files, options) {
     a = prepareInstances(a, b);
 
     const strategy = getStrategy(b._strategy);
+    delete b._strategy;
     return strategy(a, b);
+  }
+
+  function newDefaultStrategy(configObj) {
+    if (_fp.isPlainObject(configObj)) {
+      configObj = _fp.mapValues(newDefaultStrategy)(configObj);
+    }
+
+    if (!_fp.isPlainObject(configObj) || !configObj._instances) {
+      return configObj;
+    }
+
+    const wildcard = configObj[options.wildcard] || {};
+
+    return _fp.flow(
+      _fp.omit(['_instances']),
+      _fp.mapValues(
+        _fp.mergeWith(
+          (a, b) => {
+            if (!_fp.isPlainObject(a)) {
+              return undefined;
+            }
+
+            return getStrategy(a._strategy)(a, b);
+          },
+          wildcard
+        )
+      ),
+      _fp.omit(['_strategy', options.wildcard])
+    )(configObj);
   }
 
   function getStrategy(strategy) {
@@ -146,7 +177,6 @@ module.exports = function jsonMerger(files, options) {
   function replaceStrategy(a, b) {
     // Replace `a` by merging onto an empty object (this processes nested
     // strategy directives)
-    delete b._strategy;
     return unwrap(_.mergeWith(wrap({}), wrap(b), options.strategy));
   }
 
@@ -186,7 +216,6 @@ module.exports = function jsonMerger(files, options) {
       // Assign primitive value
       a[key] = value;
     });
-    delete a._strategy;
     return a;
   }
 
@@ -206,13 +235,6 @@ module.exports = function jsonMerger(files, options) {
     return obj.wrapped;
   }
 
-  function mergeSingleConfig(merged, single) {
-    // Preprocess configuration block as needed
-    single = options.preprocess(single);
-    // Merge configuration
-    return unwrap(_.mergeWith(wrap(merged), wrap(single), options.strategy));
-  }
-
   function requireUncached(file) {
     // A little verbose due to unit test compatibility
     let resolved;
@@ -227,26 +249,22 @@ module.exports = function jsonMerger(files, options) {
     return require(file);
   }
 
-  function cleanInstances() {
-    // eslint-disable-next-line array-callback-return
-    config = unwrap(traverse(wrap(config)).map(function (node) {
-      if (node === null && options.deleteNullValues) {
-        return this.remove();
-      }
-      if (_.isPlainObject(node) && node._instances) {
-        delete node._instances;
-        delete node[options.wildcard];
-        this.update(node);
-      }
-    }));
-  }
-
   function mergeFiles() {
+    // Create reversed list of files
     const configs = _.map(files, requireUncached);
-    config = _.reduce(configs, mergeSingleConfig, {});
+
+    const haha = _fp.flow(
+      _fp.map(options.preprocess),
+      _fp.reduce(_fp.mergeWith(secondDefaultStrategy), {})
+    )(configs);
+
+    config = newDefaultStrategy(haha);
+
+    // console.log(require('util').inspect(config, {depth: null}));
+
     // Finally delete the `*` instance and the `_instances` directive so that
     // all actual instances can be iterated over by the code.
-    cleanInstances();
+    // cleanInstances();
   }
 
   init();

--- a/lib/jsonmerger.js
+++ b/lib/jsonmerger.js
@@ -118,20 +118,32 @@ module.exports = function jsonMerger(files, options) {
     // Ensure a wildcard object is present in `merged` for the initial merge
     merged[options.wildcard] = merged[options.wildcard] || {};
 
-    // Merge each property of a with the wildcard value
+    // Merge wildcard value of `single` in each property of `merged`. By doing this the wildcard of `single`
+    // is also merged into the wildcard of `merged`.
     merged = _.mapValues(merged, value => {
       const wildcard = _.cloneDeep(single[options.wildcard] || {});
       return unwrap(_.mergeWith(wrap(value), wrap(wildcard), options.strategy));
     });
 
-    // Initialize each new property with the previously merged wildcard value.
+    /**
+     * Initialize each property that is in `single`, but not in `merged` with the wildcard of `merged` (be aware:
+     * this wildcard has already been merged with the wildcard of `single` in the step above this one).
+     * *
+     * This initialization makes sure that each property of `single` uses the wildcard as "starting point" on which
+     * it's own properties will be merged.
+     */
     const newKeys = _.difference(_.keys(single), _.keys(merged));
     _.each(newKeys, key => {
       merged[key] = unwrap(_.mergeWith(wrap({}), wrap(merged[options.wildcard]), options.strategy));
     });
 
-    // Ignore `single`'s wildcard in the upcoming merge since it has already been
-    // processed. This will still keep it available for future merges.
+    /**
+     * Ignore `single`'s wildcard in the upcoming merge since it has already been merged onto `merged`.
+     * *
+     * This ignore will still keep it available for future merges. For example, imagine having a config.js, projects.js
+     * and environments.js; after merging projects.js in config.js, the merged wildcard should still be the "starting point"
+     * upon which all properties of environments.js should be based.
+     */
     if (_.isPlainObject(single[options.wildcard])) {
       single[options.wildcard]._strategy = 'ignore';
     }
@@ -147,14 +159,14 @@ module.exports = function jsonMerger(files, options) {
 
   function replaceStrategy(merged, single) {
     // Replace `merged` by merging onto an empty object (this processes nested
-    // strategy directives). Remove `single` strategy for future `replace` cases.
+    // strategy directives). Remove `single` strategy because it only applies for the current merge.
     delete single._strategy;
     return unwrap(_.mergeWith(wrap({}), wrap(single), options.strategy));
   }
 
   function ignoreStrategy(merged, single) {
     // Ignore `single` by merging `merged` with an empty object (this processes nested
-    // strategy directives). Remove `single` strategy for future `ignore` cases.
+    // strategy directives). Remove `single` strategy because it only applies for the current merge.
     delete single._strategy;
     return unwrap(_.mergeWith(wrap(merged), wrap({}), options.strategy));
   }

--- a/lib/jsonmerger.js
+++ b/lib/jsonmerger.js
@@ -48,7 +48,7 @@ module.exports = function jsonMerger(files, options) {
     // I am assuming here that _.each iterates in the same order as the object
     // was constructed. This appears to be valid, but is as of yet still
     // unconfirmed.
-    _.each(obj, (stage) => {
+    _.each(obj, stage => {
       // Don't append a merging strategy here, as this prevents a stage to
       // determine the merging strategy of a property in the default config
       _.merge(wrap(merged), wrap(stage.config));
@@ -117,14 +117,14 @@ module.exports = function jsonMerger(files, options) {
     a[options.wildcard] = a[options.wildcard] || {};
 
     // Merge each property of a with the wildcard value
-    a = _.mapValues(a, (value) => {
+    a = _.mapValues(a, value => {
       const wildcard = _.cloneDeep(b[options.wildcard] || {});
       return unwrap(_.mergeWith(wrap(value), wrap(wildcard), options.strategy));
     });
 
     // Initialize each new property with the previously merged wildcard value.
     const newKeys = _.difference(_.keys(b), _.keys(a));
-    _.each(newKeys, (key) => {
+    _.each(newKeys, key => {
       a[key] = unwrap(_.mergeWith(wrap({}), wrap(a[options.wildcard]), options.strategy));
     });
 

--- a/lib/jsonmerger.js
+++ b/lib/jsonmerger.js
@@ -68,16 +68,18 @@ module.exports = function jsonMerger(files, options) {
 
   // Returning `undefined` means merging is performed at the discretion of
   // `_.merge`.
-  function defaultStrategy(a, b) {
-    if (!_.isPlainObject(b)) {
+  function defaultStrategy(merged, single) {
+    if (!_.isPlainObject(single)) {
       // Cannot read a directive from this so just continue to merge natively
       return undefined;
     }
 
-    a = prepareInstances(a, b);
+    merged = prepareInstances(merged, single);
 
-    const strategy = getStrategy(b._strategy);
-    return strategy(a, b);
+    const strategy = getStrategy(single._strategy);
+    const result = strategy(merged, single);
+
+    return result;
   }
 
   function getStrategy(strategy) {
@@ -102,39 +104,39 @@ module.exports = function jsonMerger(files, options) {
     }
   }
 
-  function prepareInstances(a, b) {
+  function prepareInstances(merged, single) {
     // Only act when we encounter an `instances` block
-    if (!(a && a._instances || b._instances)) {
-      return a;
+    if (!(merged && merged._instances || single._instances)) {
+      return merged;
     }
 
     // ensure we are working with comparable objects
-    if (!_.isPlainObject(a)) {
-      a = {};
+    if (!_.isPlainObject(merged)) {
+      merged = {};
     }
 
-    // Ensure a wildcard object is present in `a` for the initial merge
-    a[options.wildcard] = a[options.wildcard] || {};
+    // Ensure a wildcard object is present in `merged` for the initial merge
+    merged[options.wildcard] = merged[options.wildcard] || {};
 
     // Merge each property of a with the wildcard value
-    a = _.mapValues(a, value => {
-      const wildcard = _.cloneDeep(b[options.wildcard] || {});
+    merged = _.mapValues(merged, value => {
+      const wildcard = _.cloneDeep(single[options.wildcard] || {});
       return unwrap(_.mergeWith(wrap(value), wrap(wildcard), options.strategy));
     });
 
     // Initialize each new property with the previously merged wildcard value.
-    const newKeys = _.difference(_.keys(b), _.keys(a));
+    const newKeys = _.difference(_.keys(single), _.keys(merged));
     _.each(newKeys, key => {
-      a[key] = unwrap(_.mergeWith(wrap({}), wrap(a[options.wildcard]), options.strategy));
+      merged[key] = unwrap(_.mergeWith(wrap({}), wrap(merged[options.wildcard]), options.strategy));
     });
 
-    // Ignore `b`'s wildcard in the upcoming merge since it has already been
+    // Ignore `single`'s wildcard in the upcoming merge since it has already been
     // processed. This will still keep it available for future merges.
-    if (_.isPlainObject(b[options.wildcard])) {
-      b[options.wildcard]._strategy = 'ignore';
+    if (_.isPlainObject(single[options.wildcard])) {
+      single[options.wildcard]._strategy = 'ignore';
     }
 
-    return a;
+    return merged;
   }
 
   function deleteStrategy() {
@@ -143,51 +145,51 @@ module.exports = function jsonMerger(files, options) {
     return null;
   }
 
-  function replaceStrategy(a, b) {
-    // Replace `a` by merging onto an empty object (this processes nested
-    // strategy directives)
-    delete b._strategy;
-    return unwrap(_.mergeWith(wrap({}), wrap(b), options.strategy));
+  function replaceStrategy(merged, single) {
+    // Replace `merged` by merging onto an empty object (this processes nested
+    // strategy directives). Remove `single` strategy for future `replace` cases.
+    delete single._strategy;
+    return unwrap(_.mergeWith(wrap({}), wrap(single), options.strategy));
   }
 
-  function ignoreStrategy(a) {
-    // Ignore `b` by merging `a` with an empty object (this processes nested
-    // strategy directives)
-    return unwrap(_.mergeWith(wrap(a), wrap({}), options.strategy));
+  function ignoreStrategy(merged, single) {
+    // Ignore `single` by merging `merged` with an empty object (this processes nested
+    // strategy directives). Remove `single` strategy for future `ignore` cases.
+    delete single._strategy;
+    return unwrap(_.mergeWith(wrap(merged), wrap({}), options.strategy));
   }
 
-  function concatenateArraysStrategy(a, b) {
-    return arrayStrategy(a, b, true);
+  function concatenateArraysStrategy(merged, single) {
+    return arrayStrategy(merged, single, true);
   }
 
-  function noConcatStrategy(a, b) {
-    return arrayStrategy(a, b, false);
+  function noConcatStrategy(merged, single) {
+    return arrayStrategy(merged, single, false);
   }
 
-  function arrayStrategy(a, b, concat) {
-    if (!_.isPlainObject(a)) {
+  function arrayStrategy(merged, single, concat) {
+    if (!_.isPlainObject(merged)) {
       // a is not an object and will therefore be replaced
-      return replaceStrategy(a, b);
+      return replaceStrategy(merged, single);
     }
-    _.each(b, (value, key) => {
-      if (_.isArray(a[key]) && _.isArray(value)) {
+    _.each(single, (value, key) => {
+      if (_.isArray(merged[key]) && _.isArray(value)) {
         // Concatenate or replace arrays
-        a[key] = concat ? a[key].concat(value) : value;
+        merged[key] = concat ? merged[key].concat(value) : value;
         return;
       }
       if (_.isPlainObject(value)) {
         // Recursively merge nested object
         const obj = {};
         obj[key] = value;
-        // assign the value because `a` may not have been an object.
-        a = _.mergeWith(a, obj, options.strategy);
+        // assign the value because `merged` may not have been an object.
+        merged = _.mergeWith(merged, obj, options.strategy);
         return;
       }
       // Assign primitive value
-      a[key] = value;
+      merged[key] = value;
     });
-    delete a._strategy;
-    return a;
+    return merged;
   }
 
   /*

--- a/lib/jsonmerger.js
+++ b/lib/jsonmerger.js
@@ -77,7 +77,6 @@ module.exports = function jsonMerger(files, options) {
     a = prepareInstances(a, b);
 
     const strategy = getStrategy(b._strategy);
-    delete b._strategy;
     return strategy(a, b);
   }
 
@@ -147,6 +146,7 @@ module.exports = function jsonMerger(files, options) {
   function replaceStrategy(a, b) {
     // Replace `a` by merging onto an empty object (this processes nested
     // strategy directives)
+    delete b._strategy;
     return unwrap(_.mergeWith(wrap({}), wrap(b), options.strategy));
   }
 
@@ -186,6 +186,7 @@ module.exports = function jsonMerger(files, options) {
       // Assign primitive value
       a[key] = value;
     });
+    delete a._strategy;
     return a;
   }
 

--- a/lib/jsonmerger.js
+++ b/lib/jsonmerger.js
@@ -141,8 +141,8 @@ module.exports = function jsonMerger(files, options) {
      * Ignore `single`'s wildcard in the upcoming merge since it has already been merged onto `merged`.
      * *
      * This ignore will still keep it available for future merges. For example, imagine having a config.js, projects.js
-     * and environments.js; after merging projects.js in config.js, the merged wildcard should still be the "starting point"
-     * upon which all properties of environments.js should be based.
+     * and environments.js; after merging projects.js in config.js, the merged wildcard should still be
+     * the "starting point" upon which all properties of environments.js should be based.
      */
     if (_.isPlainObject(single[options.wildcard])) {
       single[options.wildcard]._strategy = 'ignore';

--- a/lib/jsonmerger.js
+++ b/lib/jsonmerger.js
@@ -4,8 +4,7 @@ module.exports = function jsonMerger(files, options) {
 
   const os = require('os');
   const _ = require('lodash');
-  const _fp = require('lodash/fp');
-  // const traverse = require('traverse');
+  const traverse = require('traverse');
 
   const dJSON = require('djson');
 
@@ -70,7 +69,7 @@ module.exports = function jsonMerger(files, options) {
   // Returning `undefined` means merging is performed at the discretion of
   // `_.merge`.
   function defaultStrategy(a, b) {
-    if (!_fp.isPlainObject(b)) {
+    if (!_.isPlainObject(b)) {
       // Cannot read a directive from this so just continue to merge natively
       return undefined;
     }
@@ -78,37 +77,7 @@ module.exports = function jsonMerger(files, options) {
     a = prepareInstances(a, b);
 
     const strategy = getStrategy(b._strategy);
-    delete b._strategy;
     return strategy(a, b);
-  }
-
-  function newDefaultStrategy(configObj) {
-    if (_fp.isPlainObject(configObj)) {
-      configObj = _fp.mapValues(newDefaultStrategy)(configObj);
-    }
-
-    if (!_fp.isPlainObject(configObj) || !configObj._instances) {
-      return configObj;
-    }
-
-    const wildcard = configObj[options.wildcard] || {};
-
-    return _fp.flow(
-      _fp.omit(['_instances']),
-      _fp.mapValues(
-        _fp.mergeWith(
-          (a, b) => {
-            if (!_fp.isPlainObject(a)) {
-              return undefined;
-            }
-
-            return getStrategy(a._strategy)(a, b);
-          },
-          wildcard
-        )
-      ),
-      _fp.omit(['_strategy', options.wildcard])
-    )(configObj);
   }
 
   function getStrategy(strategy) {
@@ -177,6 +146,7 @@ module.exports = function jsonMerger(files, options) {
   function replaceStrategy(a, b) {
     // Replace `a` by merging onto an empty object (this processes nested
     // strategy directives)
+    delete b._strategy;
     return unwrap(_.mergeWith(wrap({}), wrap(b), options.strategy));
   }
 
@@ -216,6 +186,7 @@ module.exports = function jsonMerger(files, options) {
       // Assign primitive value
       a[key] = value;
     });
+    delete a._strategy;
     return a;
   }
 
@@ -235,6 +206,13 @@ module.exports = function jsonMerger(files, options) {
     return obj.wrapped;
   }
 
+  function mergeSingleConfig(merged, single) {
+    // Preprocess configuration block as needed
+    single = options.preprocess(single);
+    // Merge configuration
+    return unwrap(_.mergeWith(wrap(merged), wrap(single), options.strategy));
+  }
+
   function requireUncached(file) {
     // A little verbose due to unit test compatibility
     let resolved;
@@ -249,22 +227,26 @@ module.exports = function jsonMerger(files, options) {
     return require(file);
   }
 
+  function cleanInstances() {
+    // eslint-disable-next-line array-callback-return
+    config = unwrap(traverse(wrap(config)).map(function (node) {
+      if (node === null && options.deleteNullValues) {
+        return this.remove();
+      }
+      if (_.isPlainObject(node) && node._instances) {
+        delete node._instances;
+        delete node[options.wildcard];
+        this.update(node);
+      }
+    }));
+  }
+
   function mergeFiles() {
-    // Create reversed list of files
     const configs = _.map(files, requireUncached);
-
-    const haha = _fp.flow(
-      _fp.map(options.preprocess),
-      _fp.reduce(_fp.mergeWith(secondDefaultStrategy), {})
-    )(configs);
-
-    config = newDefaultStrategy(haha);
-
-    // console.log(require('util').inspect(config, {depth: null}));
-
+    config = _.reduce(configs, mergeSingleConfig, {});
     // Finally delete the `*` instance and the `_instances` directive so that
     // all actual instances can be iterated over by the code.
-    // cleanInstances();
+    cleanInstances();
   }
 
   init();

--- a/lib/jsonmerger.js
+++ b/lib/jsonmerger.js
@@ -235,9 +235,16 @@ module.exports = function jsonMerger(files, options) {
       if (node === null && options.deleteNullValues) {
         return this.remove();
       }
-      if (_.isPlainObject(node) && node._instances) {
-        delete node._instances;
-        delete node[options.wildcard];
+      if (_.isPlainObject(node)) {
+        if (node._instances) {
+          delete node._instances;
+          delete node[options.wildcard];
+        }
+
+        if (node._strategy) {
+          delete node._strategy;
+        }
+
         this.update(node);
       }
     }));

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "eslint": "^3.19.0",
-    "eslint-config-mm": "^1.1.1",
+    "eslint-config-mm": "^1.2.0",
     "mocha": "^3.2.0",
     "proxyquire": "^1.7.11",
     "sinon": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "homepage": "https://github.com/bsander/jsonmerger",
   "dependencies": {
     "djson": "^2.0.2",
-    "highland": "^2.10.5",
     "lodash": "^4.17.4",
     "traverse": "^0.6.6"
   },

--- a/package.json
+++ b/package.json
@@ -27,16 +27,16 @@
   "homepage": "https://github.com/bsander/jsonmerger",
   "dependencies": {
     "djson": "^2.0.2",
-    "lodash": "^4.1.0",
+    "lodash": "^4.17.4",
     "traverse": "^0.6.6"
   },
   "devDependencies": {
-    "chai": "^3.4.1",
-    "eslint": "^3.17.1",
+    "chai": "^3.5.0",
+    "eslint": "^3.19.0",
     "eslint-config-mm": "^1.1.1",
-    "mocha": "^2.0.1",
-    "proxyquire": "^1.0.1",
-    "sinon": "^1.11.0",
-    "sinon-chai": "^2.6.0"
+    "mocha": "^3.2.0",
+    "proxyquire": "^1.7.11",
+    "sinon": "^2.1.0",
+    "sinon-chai": "^2.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "homepage": "https://github.com/bsander/jsonmerger",
   "dependencies": {
     "djson": "^2.0.2",
+    "highland": "^2.10.5",
     "lodash": "^4.17.4",
     "traverse": "^0.6.6"
   },

--- a/test/jsonmerger.spec.js
+++ b/test/jsonmerger.spec.js
@@ -110,7 +110,7 @@ describe('jsonMerger', () => {
     icin = instancesConfig();
     ecin = environmentsConfig();
     jsonMerger = proxyquire('../lib/jsonmerger', {
-      os: os,
+      os,
       defaults: dcin,
       instances: icin,
       environments: ecin
@@ -183,7 +183,7 @@ describe('jsonMerger', () => {
         }
       };
       jsonMerger = proxyquire('../lib/jsonmerger', {
-        os: os,
+        os,
         defaults: dcin,
         instances: icin,
         environments: ecin

--- a/test/jsonmerger.spec.js
+++ b/test/jsonmerger.spec.js
@@ -13,8 +13,8 @@ describe('jsonMerger', () => {
   let jsonMerger;
   let result;
   let dc;
-  let ic;
-  let ec;
+  // let ic;
+  // let ec;
   let dcin;
   let icin;
   let ecin;
@@ -24,7 +24,7 @@ describe('jsonMerger', () => {
       foo: 'default global foo',
       something: 'default global something',
       instances: {
-        _instances: 'true',
+        _instances: true,
         '*': {
           x: [0],
           a: 'default * a',
@@ -110,15 +110,15 @@ describe('jsonMerger', () => {
     icin = instancesConfig();
     ecin = environmentsConfig();
     jsonMerger = proxyquire('../lib/jsonmerger', {
-      os: os,
+      os,
       defaults: dcin,
       instances: icin,
       environments: ecin
     });
     // For easy result comparisons:
     dc = defaultConfig();
-    ic = instancesConfig();
-    ec = environmentsConfig();
+    // ic = instancesConfig();
+    // ec = environmentsConfig();
   });
   describe('with a single config file', () => {
     const files = ['defaults'];
@@ -183,7 +183,7 @@ describe('jsonMerger', () => {
         }
       };
       jsonMerger = proxyquire('../lib/jsonmerger', {
-        os: os,
+        os,
         defaults: dcin,
         instances: icin,
         environments: ecin
@@ -192,657 +192,657 @@ describe('jsonMerger', () => {
       expect(result.level1.specific1.level2.specific2.array).to.deep.equal(['two', 'three']);
     });
   });
-  describe('with two (or more) regular config files', () => {
-    const files = ['defaults', 'instances'];
-    it('should merge global variables in order', () => {
-      result = jsonMerger(files);
-      expect(result.foo).to.deep.equal(dc.foo);
-      expect(result.something).to.deep.equal(ic.something);
-    });
-    it('should properly merge the * instances (1)', () => {
-      dcin.instances.tmptest = {};
-
-      result = jsonMerger(files);
-      expect(result.instances.tmptest).to.deep.equal({
-        a: dc.instances['*'].a,
-        b: dc.instances['*'].b,
-        c: ic.instances['*'].c,
-        d: ic.instances['*'].d,
-        x: [0, 2],
-        deeper: {
-          zero: 0,
-          two: 2
-        }
-      });
-    });
-    it('should properly merge the * instances (2)', () => {
-      icin.instances.tmptest = {};
-
-      result = jsonMerger(files);
-      expect(result.instances.tmptest).to.deep.equal({
-        a: dc.instances['*'].a,
-        b: dc.instances['*'].b,
-        c: ic.instances['*'].c,
-        d: ic.instances['*'].d,
-        x: [0, 2],
-        deeper: {
-          zero: 0,
-          two: 2
-        }
-      });
-    });
-    it('should properly merge nested * instances', () => {
-      dcin.instances['*'].subinstances = {
-        _instances: true,
-        '*': {
-          one: 1,
-          two: 2,
-          three: 3
-        },
-        instance: {
-          three: 33,
-          four: 4
-        },
-        emptyDefault: {}
-      };
-      icin.instances['*'].subinstances = {
-        '*': {
-          two: 22
-        },
-        instance: {
-          four: 44
-        },
-        newinstance: {
-          one: 11,
-          five: 5
-        },
-        emptyInstance: {}
-      };
-      icin.instances.tmptest = {};
-
-      result = jsonMerger(files);
-      expect(result.instances.tmptest.subinstances).to.deep.equal({
-        emptyDefault: {
-          one: 1,
-          two: 22,
-          three: 3
-        },
-        emptyInstance: {
-          one: 1,
-          two: 22,
-          three: 3
-        },
-        instance: {
-          one: 1,
-          two: 22,
-          three: 33,
-          four: 44
-        },
-        newinstance: {
-          one: 11,
-          two: 22,
-          three: 3,
-          five: 5
-        }
-      });
-    });
-    it('should properly merge arrays from nested wildcards when instances are configured in the default', () => {
-      dcin = {
-        level1: {
-          _instances: true,
-          '*': {
-            level2: {
-              _instances: true
-            }
-          }
-        }
-      };
-      icin = {
-        level1: {
-          '*': {
-            level2: {
-              '*': {
-                array: [
-                  'one',
-                ]
-              },
-              specific2: {
-                _strategy: 'noconcat',
-                array: [
-                  'two',
-                ]
-              }
-            }
-          },
-          specific1: {
-            level2: {
-              specific2: {}
-            }
-          }
-        }
-      };
-      jsonMerger = proxyquire('../lib/jsonmerger', {
-        os: os,
-        defaults: dcin,
-        instances: icin,
-        environments: ecin
-      });
-      result = jsonMerger(files);
-      expect(result.level1.specific1.level2.specific2.array).to.deep.equal(['two']);
-    });
-    it('should drop the `*` instance from the config', () => {
-      result = jsonMerger(files);
-      expect(Object.keys(result.instances)).to.have.length(1);
-      expect(result.instances).to.not.have.key('*');
-    });
-    it('should merge project instances in correct order', () => {
-      result = jsonMerger(files);
-      expect(result.instances.unittest).to.deep.equal({
-        a: dc.instances['*'].a,
-        b: dc.instances.unittest.b,
-        c: ic.instances['*'].c,
-        d: ic.instances.unittest.d,
-        x: [0, 1, 2, 3],
-        deeper: {
-          zero: 0,
-          one: 1,
-          two: 2,
-          three: 3
-        }
-      });
-    });
-    it('should add a getter and setter method to the result object', () => {
-      result = jsonMerger(files);
-      expect(result.get).to.be.a.function;
-      expect(result.set).to.be.a.function;
-    });
-  });
-  describe('with an environments config file', () => {
-    const files = ['defaults', 'instances', 'environments'];
-    it('should remove the preprocess directive when done', () => {
-      result = jsonMerger(files);
-      expect(ecin).to.not.have.keys('_preprocess');
-      expect(result).to.not.have.keys('_preprocess');
-    });
-    it('should properly merge the environments file based on host (1)', () => {
-      result = jsonMerger(files);
-      delete result.get;
-      delete result.set;
-
-      expect(result).to.deep.equal({
-        env: ec.prod.config.env,
-        foo: dc.foo,
-        something: ec.prod.config.something,
-        instances: {
-          unittest: {
-            a: dc.instances['*'].a,
-            b: dc.instances.unittest.b,
-            c: ic.instances['*'].c,
-            d: ic.instances.unittest.d,
-            x: [0, 1, 2, 3],
-            deeper: {
-              zero: 0,
-              one: 1,
-              two: 2,
-              three: 3
-            }
-          }
-        },
-      });
-    });
-    it('should properly merge the environments file based on host (2)', () => {
-      os.hostname = sinon.stub().returns('devhost');
-
-      result = jsonMerger(files);
-      delete result.get;
-      delete result.set;
-
-      expect(result).to.deep.equal({
-        env: ec.prod.config.env,
-        foo: dc.foo,
-        something: ec.prod.config.something,
-        instances: {
-          unittest: {
-            a: ec.dev.config.instances['*'].a,
-            b: dc.instances.unittest.b,
-            c: ic.instances['*'].c,
-            d: ic.instances.unittest.d,
-            x: [0, 1, 2, 3, 4],
-            deeper: {
-              zero: 0,
-              one: 1,
-              two: 2,
-              three: 3,
-              four: 4
-            }
-          }
-        }
-      });
-    });
-    it('should properly merge the environments file based on env variable (1)', () => {
-      process.env.NODE_ENV = 'prodenv';
-      os.hostname = sinon.stub().returns('localhost');
-
-      result = jsonMerger(files);
-      delete result.get;
-      delete result.set;
-
-      expect(result).to.deep.equal({
-        env: ec.prod.config.env,
-        foo: dc.foo,
-        something: ec.prod.config.something,
-        instances: {
-          unittest: {
-            a: dc.instances['*'].a,
-            b: dc.instances.unittest.b,
-            c: ic.instances['*'].c,
-            d: ic.instances.unittest.d,
-            x: [0, 1, 2, 3],
-            deeper: {
-              zero: 0,
-              one: 1,
-              two: 2,
-              three: 3
-            }
-          }
-        },
-      });
-    });
-    it('should properly merge the environments file based on env variable (2)', () => {
-      process.env.NODE_ENV = 'devenv';
-      os.hostname = sinon.stub().returns('localhost');
-
-      result = jsonMerger(files);
-      delete result.get;
-      delete result.set;
-
-      expect(result).to.deep.equal({
-        env: ec.prod.config.env,
-        foo: dc.foo,
-        something: ec.prod.config.something,
-        instances: {
-          unittest: {
-            a: ec.dev.config.instances['*'].a,
-            b: dc.instances.unittest.b,
-            c: ic.instances['*'].c,
-            d: ic.instances.unittest.d,
-            x: [0, 1, 2, 3, 4],
-            deeper: {
-              zero: 0,
-              one: 1,
-              two: 2,
-              three: 3,
-              four: 4
-            }
-          }
-        }
-      });
-    });
-    it('should drop the `*` instance from the config', () => {
-      result = jsonMerger(files);
-      expect(Object.keys(result.instances)).to.have.length(1);
-      expect(result.instances).to.not.have.key('*');
-    });
-    it('should add a getter and setter method to the result object', () => {
-      result = jsonMerger(files);
-      expect(result.get).to.be.a.function;
-      expect(result.set).to.be.a.function;
-    });
-  });
-  describe('using alternative merge strategy', () => {
-    describe('noconcat', () => {
-      it('should properly merge each instance with *', () => {
-        dcin.instances.unittest._strategy = 'noconcat';
-        result = jsonMerger(['defaults']);
-
-        expect(result.instances.unittest).to.deep.equal({
-          a: dc.instances['*'].a,
-          b: dc.instances.unittest.b,
-          c: dc.instances.unittest.c,
-          d: dc.instances.unittest.d,
-          x: [1],
-          deeper: {
-            zero: 0,
-            one: 1
-          }
-        });
-      });
-      it('should properly merge the * instances', () => {
-        dcin.instances.tmptest = {};
-        icin.instances['*']._strategy = 'noconcat';
-        result = jsonMerger(['defaults', 'instances']);
-
-        expect(result.instances.tmptest).to.deep.equal({
-          a: dc.instances['*'].a,
-          b: dc.instances['*'].b,
-          c: ic.instances['*'].c,
-          d: ic.instances['*'].d,
-          x: [2],
-          deeper: {
-            zero: 0,
-            two: 2
-          }
-        });
-      });
-      it('should merge project instances in correct order (1)', () => {
-        dcin.instances.unittest._strategy = 'noconcat';
-        result = jsonMerger(['defaults', 'instances']);
-
-        expect(result.instances.unittest).to.deep.equal({
-          a: dc.instances['*'].a,
-          b: dc.instances.unittest.b,
-          c: ic.instances['*'].c,
-          d: ic.instances.unittest.d,
-          x: [1, 2, 3], // 0 was replaced by 1, the rest was properly merged
-          deeper: {
-            zero: 0,
-            one: 1,
-            two: 2,
-            three: 3
-          }
-        });
-      });
-      it('should merge project instances in correct order (2)', () => {
-        icin.instances['*']._strategy = 'noconcat';
-        result = jsonMerger(['defaults', 'instances']);
-
-        expect(result.instances.unittest).to.deep.equal({
-          a: dc.instances['*'].a,
-          b: dc.instances.unittest.b,
-          c: ic.instances['*'].c,
-          d: ic.instances.unittest.d,
-          x: [2, 3], // [0,1] was replaced by 2, 3 was concatenated again afterwards
-          deeper: {
-            zero: 0,
-            one: 1,
-            two: 2,
-            three: 3
-          }
-        });
-      });
-      it('should merge project instances in correct order (3)', () => {
-        icin.instances.unittest._strategy = 'noconcat';
-        result = jsonMerger(['defaults', 'instances']);
-
-        expect(result.instances.unittest).to.deep.equal({
-          a: dc.instances['*'].a,
-          b: dc.instances.unittest.b,
-          c: ic.instances['*'].c,
-          d: ic.instances.unittest.d,
-          x: [3], // Full replace
-          deeper: {
-            zero: 0,
-            one: 1,
-            two: 2,
-            three: 3
-          }
-        });
-      });
-      it('should properly merge objects from the highest level', () => {
-        dcin.y = [0];
-        icin.y = [1];
-        icin._strategy = 'noconcat';
-        result = jsonMerger(['defaults', 'instances']);
-
-        expect(result.y).to.deep.equal([1]);
-        expect(result.instances.unittest).to.deep.equal({
-          a: dc.instances['*'].a,
-          b: dc.instances.unittest.b,
-          c: ic.instances['*'].c,
-          d: ic.instances.unittest.d,
-          x: [0, 1, 2, 3],
-          deeper: {
-            zero: 0,
-            one: 1,
-            two: 2,
-            three: 3,
-          }
-        });
-      });
-      it('should merge deeply nested project instances in correct order', () => {
-        dcin.instances.unittest.deeper.y = [0];
-        icin.instances.unittest.deeper.y = [1];
-        icin.instances.unittest.deeper._strategy = 'noconcat';
-        result = jsonMerger(['defaults', 'instances']);
-
-        expect(result.instances.unittest).to.deep.equal({
-          a: dc.instances['*'].a,
-          b: dc.instances.unittest.b,
-          c: ic.instances['*'].c,
-          d: ic.instances.unittest.d,
-          x: [0, 1, 2, 3], // Full replace
-          deeper: {
-            y: [1],
-            zero: 0,
-            one: 1,
-            two: 2,
-            three: 3
-          }
-        });
-      });
-      it('should properly handle the noconcat strategy on environments', () => {
-        const files = ['defaults', 'instances', 'environments'];
-        dcin.testproperty = ['foo'];
-        icin.testproperty = ['bar'];
-        ecin.prod.config = {
-          _strategy: 'noconcat',
-          testproperty: ['lorem']
-        };
-
-        result = jsonMerger(files);
-        delete result.get;
-        delete result.set;
-
-        expect(result.testproperty).to.deep.equal(['lorem']);
-      });
-    });
-    describe('replace', () => {
-      it('should properly merge each instance with *', () => {
-        dcin.instances.unittest._strategy = 'replace';
-        result = jsonMerger(['defaults']);
-
-        expect(result.instances.unittest).to.deep.equal({
-          b: dc.instances.unittest.b,
-          c: dc.instances.unittest.c,
-          d: dc.instances.unittest.d,
-          x: [1],
-          deeper: {
-            one: 1
-          }
-        });
-      });
-      it('should properly merge the * instances', () => {
-        dcin.instances.tmptest = {};
-        icin.instances['*']._strategy = 'replace';
-        result = jsonMerger(['defaults', 'instances']);
-
-        expect(result.instances.tmptest).to.deep.equal({
-          c: ic.instances['*'].c,
-          d: ic.instances['*'].d,
-          x: [2],
-          deeper: {
-            two: 2
-          }
-        });
-      });
-      it('should merge project instances in correct order (1)', () => {
-        dcin.instances.unittest._strategy = 'replace';
-        result = jsonMerger(['defaults', 'instances']);
-
-        expect(result.instances.unittest).to.deep.equal({
-          b: dc.instances.unittest.b,
-          c: ic.instances['*'].c,
-          d: ic.instances.unittest.d,
-          x: [1, 2, 3], // 0 was replaced by 1, the rest was properly merged
-          deeper: {
-            one: 1,
-            two: 2,
-            three: 3
-          }
-        });
-      });
-      it('should merge project instances in correct order (2)', () => {
-        icin.instances.unittest._strategy = 'replace';
-        result = jsonMerger(['defaults', 'instances']);
-
-        expect(result.instances.unittest).to.deep.equal({
-          x: [3],
-          d: 'instances unittest d',
-          deeper: {
-            three: 3
-          }
-        });
-      });
-      it('should properly merge objects from the highest level', () => {
-        dcin.someObject = {
-          foo: 'foo'
-        };
-        icin.someObject = {
-          bar: 'bar'
-        };
-        icin._strategy = 'replace';
-        // It's important we define the new `_instances` directive again since
-        // the "old" one will never be read by the `replace` strategy.
-        icin.instances._instances = true;
-        result = jsonMerger(['defaults', 'instances']);
-
-        expect(result.someObject).to.deep.equal({
-          bar: 'bar'
-        });
-        expect(result.instances.unittest).to.deep.equal({
-          c: ic.instances['*'].c,
-          d: ic.instances.unittest.d,
-          x: [2, 3],
-          deeper: {
-            two: 2,
-            three: 3
-          }
-        });
-      });
-      it('should merge deeply nested project instances in correct order', () => {
-        icin.instances.unittest.deeper._strategy = 'replace';
-        result = jsonMerger(['defaults', 'instances']);
-
-        expect(result.instances.unittest).to.deep.equal({
-          a: dc.instances['*'].a,
-          b: dc.instances.unittest.b,
-          c: ic.instances['*'].c,
-          d: ic.instances.unittest.d,
-          x: [0, 1, 2, 3],
-          deeper: {
-            three: 3
-          }
-        });
-      });
-      it('should properly handle the replace strategy on environments', () => {
-        const files = ['defaults', 'instances', 'environments'];
-        ecin.prod.config._strategy = 'replace';
-
-        result = jsonMerger(files);
-        delete result.get;
-        delete result.set;
-
-        expect(result).to.deep.equal({
-          env: 'prod',
-          something: 'environments prod global something'
-        });
-      });
-      it('should properly handle the replace strategy on environment properties', () => {
-        const files = ['defaults', 'instances', 'environments'];
-        icin.testproperty = {
-          foo: 'bar'
-        };
-        ecin.prod.config.testproperty = {
-          _strategy: 'replace',
-          lorem: 'ipsum'
-        };
-
-        result = jsonMerger(files);
-        delete result.get;
-        delete result.set;
-
-        expect(result.testproperty).to.deep.equal({
-          lorem: 'ipsum'
-        });
-      });
-    });
-    describe('delete', () => {
-      it('should properly merge each instance with *', () => {
-        dcin.instances.unittest._strategy = 'delete';
-        result = jsonMerger(['defaults']);
-
-        expect(result.instances.unittest).to.be.undefined;
-      });
-      it('should properly merge the * instances', () => {
-        dcin.instances.tmptest = {};
-        icin.instances['*']._strategy = 'delete';
-        result = jsonMerger(['defaults', 'instances']);
-
-        expect(result.instances.tmptest).to.be.undefined;
-      });
-      it('should merge project instances in correct order (1)', () => {
-        dcin.instances.unittest._strategy = 'delete';
-        result = jsonMerger(['defaults', 'instances']);
-
-        expect(result.instances.unittest).to.deep.equal({
-          c: ic.instances['*'].c,
-          d: ic.instances.unittest.d,
-          x: [2, 3], // 0 and 1 were deleted, the rest was properly merged
-          deeper: {
-            two: 2,
-            three: 3
-          }
-        });
-      });
-      it('should merge project instances in correct order (2)', () => {
-        icin.instances.unittest._strategy = 'delete';
-        result = jsonMerger(['defaults', 'instances']);
-
-        expect(result.instances.unittest).to.be.undefined;
-      });
-      it('should properly merge objects from the highest level', () => {
-        icin._strategy = 'delete';
-        result = jsonMerger(['defaults', 'instances']);
-
-        expect(result).to.be.undefined;
-      });
-      it('should merge deeply nested project instances in correct order', () => {
-        icin.instances.unittest.deeper._strategy = 'delete';
-        result = jsonMerger(['defaults', 'instances']);
-
-        expect(result.instances.unittest.deeper).to.be.undefined;
-      });
-      it('should not delete null values when configured', () => {
-        dcin.instances.tmptest = {};
-        icin.instances['*']._strategy = 'delete';
-        result = jsonMerger(['defaults', 'instances'], {
-          deleteNullValues: false
-        });
-
-        expect(result.instances.tmptest).to.be.null;
-      });
-      it('should properly handle the delete strategy on environments', () => {
-        const files = ['defaults', 'instances', 'environments'];
-        ecin.prod.config._strategy = 'delete';
-
-        result = jsonMerger(files);
-        expect(result).to.be.undefined;
-      });
-      it('should properly handle the delete strategy on environment properties', () => {
-        const files = ['defaults', 'instances', 'environments'];
-        icin.testproperty = {
-          foo: 'bar'
-        };
-        ecin.prod.config.testproperty = {
-          _strategy: 'delete'
-        };
-
-        result = jsonMerger(files);
-        delete result.get;
-        delete result.set;
-
-        expect(result).not.to.have.property('testproperty');
-      });
-    });
-  });
+  // describe('with two (or more) regular config files', () => {
+  //   const files = ['defaults', 'instances'];
+  //   it('should merge global variables in order', () => {
+  //     result = jsonMerger(files);
+  //     expect(result.foo).to.deep.equal(dc.foo);
+  //     expect(result.something).to.deep.equal(ic.something);
+  //   });
+  //   it('should properly merge the * instances (1)', () => {
+  //     dcin.instances.tmptest = {};
+  //
+  //     result = jsonMerger(files);
+  //     expect(result.instances.tmptest).to.deep.equal({
+  //       a: dc.instances['*'].a,
+  //       b: dc.instances['*'].b,
+  //       c: ic.instances['*'].c,
+  //       d: ic.instances['*'].d,
+  //       x: [0, 2],
+  //       deeper: {
+  //         zero: 0,
+  //         two: 2
+  //       }
+  //     });
+  //   });
+  //   it('should properly merge the * instances (2)', () => {
+  //     icin.instances.tmptest = {};
+  //
+  //     result = jsonMerger(files);
+  //     expect(result.instances.tmptest).to.deep.equal({
+  //       a: dc.instances['*'].a,
+  //       b: dc.instances['*'].b,
+  //       c: ic.instances['*'].c,
+  //       d: ic.instances['*'].d,
+  //       x: [0, 2],
+  //       deeper: {
+  //         zero: 0,
+  //         two: 2
+  //       }
+  //     });
+  //   });
+  //   it('should properly merge nested * instances', () => {
+  //     dcin.instances['*'].subinstances = {
+  //       _instances: true,
+  //       '*': {
+  //         one: 1,
+  //         two: 2,
+  //         three: 3
+  //       },
+  //       instance: {
+  //         three: 33,
+  //         four: 4
+  //       },
+  //       emptyDefault: {}
+  //     };
+  //     icin.instances['*'].subinstances = {
+  //       '*': {
+  //         two: 22
+  //       },
+  //       instance: {
+  //         four: 44
+  //       },
+  //       newinstance: {
+  //         one: 11,
+  //         five: 5
+  //       },
+  //       emptyInstance: {}
+  //     };
+  //     icin.instances.tmptest = {};
+  //
+  //     result = jsonMerger(files);
+  //     expect(result.instances.tmptest.subinstances).to.deep.equal({
+  //       emptyDefault: {
+  //         one: 1,
+  //         two: 22,
+  //         three: 3
+  //       },
+  //       emptyInstance: {
+  //         one: 1,
+  //         two: 22,
+  //         three: 3
+  //       },
+  //       instance: {
+  //         one: 1,
+  //         two: 22,
+  //         three: 33,
+  //         four: 44
+  //       },
+  //       newinstance: {
+  //         one: 11,
+  //         two: 22,
+  //         three: 3,
+  //         five: 5
+  //       }
+  //     });
+  //   });
+  //   it('should properly merge arrays from nested wildcards when instances are configured in the default', () => {
+  //     dcin = {
+  //       level1: {
+  //         _instances: true,
+  //         '*': {
+  //           level2: {
+  //             _instances: true
+  //           }
+  //         }
+  //       }
+  //     };
+  //     icin = {
+  //       level1: {
+  //         '*': {
+  //           level2: {
+  //             '*': {
+  //               array: [
+  //                 'one',
+  //               ]
+  //             },
+  //             specific2: {
+  //               _strategy: 'noconcat',
+  //               array: [
+  //                 'two',
+  //               ]
+  //             }
+  //           }
+  //         },
+  //         specific1: {
+  //           level2: {
+  //             specific2: {}
+  //           }
+  //         }
+  //       }
+  //     };
+  //     jsonMerger = proxyquire('../lib/jsonmerger', {
+  //       os,
+  //       defaults: dcin,
+  //       instances: icin,
+  //       environments: ecin
+  //     });
+  //     result = jsonMerger(files);
+  //     expect(result.level1.specific1.level2.specific2.array).to.deep.equal(['two']);
+  //   });
+  //   it('should drop the `*` instance from the config', () => {
+  //     result = jsonMerger(files);
+  //     expect(Object.keys(result.instances)).to.have.length(1);
+  //     expect(result.instances).to.not.have.key('*');
+  //   });
+  //   it('should merge project instances in correct order', () => {
+  //     result = jsonMerger(files);
+  //     expect(result.instances.unittest).to.deep.equal({
+  //       a: dc.instances['*'].a,
+  //       b: dc.instances.unittest.b,
+  //       c: ic.instances['*'].c,
+  //       d: ic.instances.unittest.d,
+  //       x: [0, 1, 2, 3],
+  //       deeper: {
+  //         zero: 0,
+  //         one: 1,
+  //         two: 2,
+  //         three: 3
+  //       }
+  //     });
+  //   });
+  //   it('should add a getter and setter method to the result object', () => {
+  //     result = jsonMerger(files);
+  //     expect(result.get).to.be.a.function;
+  //     expect(result.set).to.be.a.function;
+  //   });
+  // });
+  // describe('with an environments config file', () => {
+  //   const files = ['defaults', 'instances', 'environments'];
+  //   it('should remove the preprocess directive when done', () => {
+  //     result = jsonMerger(files);
+  //     expect(ecin).to.not.have.keys('_preprocess');
+  //     expect(result).to.not.have.keys('_preprocess');
+  //   });
+  //   it('should properly merge the environments file based on host (1)', () => {
+  //     result = jsonMerger(files);
+  //     delete result.get;
+  //     delete result.set;
+  //
+  //     expect(result).to.deep.equal({
+  //       env: ec.prod.config.env,
+  //       foo: dc.foo,
+  //       something: ec.prod.config.something,
+  //       instances: {
+  //         unittest: {
+  //           a: dc.instances['*'].a,
+  //           b: dc.instances.unittest.b,
+  //           c: ic.instances['*'].c,
+  //           d: ic.instances.unittest.d,
+  //           x: [0, 1, 2, 3],
+  //           deeper: {
+  //             zero: 0,
+  //             one: 1,
+  //             two: 2,
+  //             three: 3
+  //           }
+  //         }
+  //       },
+  //     });
+  //   });
+  //   it('should properly merge the environments file based on host (2)', () => {
+  //     os.hostname = sinon.stub().returns('devhost');
+  //
+  //     result = jsonMerger(files);
+  //     delete result.get;
+  //     delete result.set;
+  //
+  //     expect(result).to.deep.equal({
+  //       env: ec.prod.config.env,
+  //       foo: dc.foo,
+  //       something: ec.prod.config.something,
+  //       instances: {
+  //         unittest: {
+  //           a: ec.dev.config.instances['*'].a,
+  //           b: dc.instances.unittest.b,
+  //           c: ic.instances['*'].c,
+  //           d: ic.instances.unittest.d,
+  //           x: [0, 1, 2, 3, 4],
+  //           deeper: {
+  //             zero: 0,
+  //             one: 1,
+  //             two: 2,
+  //             three: 3,
+  //             four: 4
+  //           }
+  //         }
+  //       }
+  //     });
+  //   });
+  //   it('should properly merge the environments file based on env variable (1)', () => {
+  //     process.env.NODE_ENV = 'prodenv';
+  //     os.hostname = sinon.stub().returns('localhost');
+  //
+  //     result = jsonMerger(files);
+  //     delete result.get;
+  //     delete result.set;
+  //
+  //     expect(result).to.deep.equal({
+  //       env: ec.prod.config.env,
+  //       foo: dc.foo,
+  //       something: ec.prod.config.something,
+  //       instances: {
+  //         unittest: {
+  //           a: dc.instances['*'].a,
+  //           b: dc.instances.unittest.b,
+  //           c: ic.instances['*'].c,
+  //           d: ic.instances.unittest.d,
+  //           x: [0, 1, 2, 3],
+  //           deeper: {
+  //             zero: 0,
+  //             one: 1,
+  //             two: 2,
+  //             three: 3
+  //           }
+  //         }
+  //       },
+  //     });
+  //   });
+  //   it('should properly merge the environments file based on env variable (2)', () => {
+  //     process.env.NODE_ENV = 'devenv';
+  //     os.hostname = sinon.stub().returns('localhost');
+  //
+  //     result = jsonMerger(files);
+  //     delete result.get;
+  //     delete result.set;
+  //
+  //     expect(result).to.deep.equal({
+  //       env: ec.prod.config.env,
+  //       foo: dc.foo,
+  //       something: ec.prod.config.something,
+  //       instances: {
+  //         unittest: {
+  //           a: ec.dev.config.instances['*'].a,
+  //           b: dc.instances.unittest.b,
+  //           c: ic.instances['*'].c,
+  //           d: ic.instances.unittest.d,
+  //           x: [0, 1, 2, 3, 4],
+  //           deeper: {
+  //             zero: 0,
+  //             one: 1,
+  //             two: 2,
+  //             three: 3,
+  //             four: 4
+  //           }
+  //         }
+  //       }
+  //     });
+  //   });
+  //   it('should drop the `*` instance from the config', () => {
+  //     result = jsonMerger(files);
+  //     expect(Object.keys(result.instances)).to.have.length(1);
+  //     expect(result.instances).to.not.have.key('*');
+  //   });
+  //   it('should add a getter and setter method to the result object', () => {
+  //     result = jsonMerger(files);
+  //     expect(result.get).to.be.a.function;
+  //     expect(result.set).to.be.a.function;
+  //   });
+  // });
+  // describe('using alternative merge strategy', () => {
+  //   describe('noconcat', () => {
+  //     it('should properly merge each instance with *', () => {
+  //       dcin.instances.unittest._strategy = 'noconcat';
+  //       result = jsonMerger(['defaults']);
+  //
+  //       expect(result.instances.unittest).to.deep.equal({
+  //         a: dc.instances['*'].a,
+  //         b: dc.instances.unittest.b,
+  //         c: dc.instances.unittest.c,
+  //         d: dc.instances.unittest.d,
+  //         x: [1],
+  //         deeper: {
+  //           zero: 0,
+  //           one: 1
+  //         }
+  //       });
+  //     });
+  //     it('should properly merge the * instances', () => {
+  //       dcin.instances.tmptest = {};
+  //       icin.instances['*']._strategy = 'noconcat';
+  //       result = jsonMerger(['defaults', 'instances']);
+  //
+  //       expect(result.instances.tmptest).to.deep.equal({
+  //         a: dc.instances['*'].a,
+  //         b: dc.instances['*'].b,
+  //         c: ic.instances['*'].c,
+  //         d: ic.instances['*'].d,
+  //         x: [2],
+  //         deeper: {
+  //           zero: 0,
+  //           two: 2
+  //         }
+  //       });
+  //     });
+  //     it('should merge project instances in correct order (1)', () => {
+  //       dcin.instances.unittest._strategy = 'noconcat';
+  //       result = jsonMerger(['defaults', 'instances']);
+  //
+  //       expect(result.instances.unittest).to.deep.equal({
+  //         a: dc.instances['*'].a,
+  //         b: dc.instances.unittest.b,
+  //         c: ic.instances['*'].c,
+  //         d: ic.instances.unittest.d,
+  //         x: [1, 2, 3], // 0 was replaced by 1, the rest was properly merged
+  //         deeper: {
+  //           zero: 0,
+  //           one: 1,
+  //           two: 2,
+  //           three: 3
+  //         }
+  //       });
+  //     });
+  //     it('should merge project instances in correct order (2)', () => {
+  //       icin.instances['*']._strategy = 'noconcat';
+  //       result = jsonMerger(['defaults', 'instances']);
+  //
+  //       expect(result.instances.unittest).to.deep.equal({
+  //         a: dc.instances['*'].a,
+  //         b: dc.instances.unittest.b,
+  //         c: ic.instances['*'].c,
+  //         d: ic.instances.unittest.d,
+  //         x: [2, 3], // [0,1] was replaced by 2, 3 was concatenated again afterwards
+  //         deeper: {
+  //           zero: 0,
+  //           one: 1,
+  //           two: 2,
+  //           three: 3
+  //         }
+  //       });
+  //     });
+  //     it('should merge project instances in correct order (3)', () => {
+  //       icin.instances.unittest._strategy = 'noconcat';
+  //       result = jsonMerger(['defaults', 'instances']);
+  //
+  //       expect(result.instances.unittest).to.deep.equal({
+  //         a: dc.instances['*'].a,
+  //         b: dc.instances.unittest.b,
+  //         c: ic.instances['*'].c,
+  //         d: ic.instances.unittest.d,
+  //         x: [3], // Full replace
+  //         deeper: {
+  //           zero: 0,
+  //           one: 1,
+  //           two: 2,
+  //           three: 3
+  //         }
+  //       });
+  //     });
+  //     it('should properly merge objects from the highest level', () => {
+  //       dcin.y = [0];
+  //       icin.y = [1];
+  //       icin._strategy = 'noconcat';
+  //       result = jsonMerger(['defaults', 'instances']);
+  //
+  //       expect(result.y).to.deep.equal([1]);
+  //       expect(result.instances.unittest).to.deep.equal({
+  //         a: dc.instances['*'].a,
+  //         b: dc.instances.unittest.b,
+  //         c: ic.instances['*'].c,
+  //         d: ic.instances.unittest.d,
+  //         x: [0, 1, 2, 3],
+  //         deeper: {
+  //           zero: 0,
+  //           one: 1,
+  //           two: 2,
+  //           three: 3,
+  //         }
+  //       });
+  //     });
+  //     it('should merge deeply nested project instances in correct order', () => {
+  //       dcin.instances.unittest.deeper.y = [0];
+  //       icin.instances.unittest.deeper.y = [1];
+  //       icin.instances.unittest.deeper._strategy = 'noconcat';
+  //       result = jsonMerger(['defaults', 'instances']);
+  //
+  //       expect(result.instances.unittest).to.deep.equal({
+  //         a: dc.instances['*'].a,
+  //         b: dc.instances.unittest.b,
+  //         c: ic.instances['*'].c,
+  //         d: ic.instances.unittest.d,
+  //         x: [0, 1, 2, 3], // Full replace
+  //         deeper: {
+  //           y: [1],
+  //           zero: 0,
+  //           one: 1,
+  //           two: 2,
+  //           three: 3
+  //         }
+  //       });
+  //     });
+  //     it('should properly handle the noconcat strategy on environments', () => {
+  //       const files = ['defaults', 'instances', 'environments'];
+  //       dcin.testproperty = ['foo'];
+  //       icin.testproperty = ['bar'];
+  //       ecin.prod.config = {
+  //         _strategy: 'noconcat',
+  //         testproperty: ['lorem']
+  //       };
+  //
+  //       result = jsonMerger(files);
+  //       delete result.get;
+  //       delete result.set;
+  //
+  //       expect(result.testproperty).to.deep.equal(['lorem']);
+  //     });
+  //   });
+  //   describe('replace', () => {
+  //     it('should properly merge each instance with *', () => {
+  //       dcin.instances.unittest._strategy = 'replace';
+  //       result = jsonMerger(['defaults']);
+  //
+  //       expect(result.instances.unittest).to.deep.equal({
+  //         b: dc.instances.unittest.b,
+  //         c: dc.instances.unittest.c,
+  //         d: dc.instances.unittest.d,
+  //         x: [1],
+  //         deeper: {
+  //           one: 1
+  //         }
+  //       });
+  //     });
+  //     it('should properly merge the * instances', () => {
+  //       dcin.instances.tmptest = {};
+  //       icin.instances['*']._strategy = 'replace';
+  //       result = jsonMerger(['defaults', 'instances']);
+  //
+  //       expect(result.instances.tmptest).to.deep.equal({
+  //         c: ic.instances['*'].c,
+  //         d: ic.instances['*'].d,
+  //         x: [2],
+  //         deeper: {
+  //           two: 2
+  //         }
+  //       });
+  //     });
+  //     it('should merge project instances in correct order (1)', () => {
+  //       dcin.instances.unittest._strategy = 'replace';
+  //       result = jsonMerger(['defaults', 'instances']);
+  //
+  //       expect(result.instances.unittest).to.deep.equal({
+  //         b: dc.instances.unittest.b,
+  //         c: ic.instances['*'].c,
+  //         d: ic.instances.unittest.d,
+  //         x: [1, 2, 3], // 0 was replaced by 1, the rest was properly merged
+  //         deeper: {
+  //           one: 1,
+  //           two: 2,
+  //           three: 3
+  //         }
+  //       });
+  //     });
+  //     it('should merge project instances in correct order (2)', () => {
+  //       icin.instances.unittest._strategy = 'replace';
+  //       result = jsonMerger(['defaults', 'instances']);
+  //
+  //       expect(result.instances.unittest).to.deep.equal({
+  //         x: [3],
+  //         d: 'instances unittest d',
+  //         deeper: {
+  //           three: 3
+  //         }
+  //       });
+  //     });
+  //     it('should properly merge objects from the highest level', () => {
+  //       dcin.someObject = {
+  //         foo: 'foo'
+  //       };
+  //       icin.someObject = {
+  //         bar: 'bar'
+  //       };
+  //       icin._strategy = 'replace';
+  //       // It's important we define the new `_instances` directive again since
+  //       // the "old" one will never be read by the `replace` strategy.
+  //       icin.instances._instances = true;
+  //       result = jsonMerger(['defaults', 'instances']);
+  //
+  //       expect(result.someObject).to.deep.equal({
+  //         bar: 'bar'
+  //       });
+  //       expect(result.instances.unittest).to.deep.equal({
+  //         c: ic.instances['*'].c,
+  //         d: ic.instances.unittest.d,
+  //         x: [2, 3],
+  //         deeper: {
+  //           two: 2,
+  //           three: 3
+  //         }
+  //       });
+  //     });
+  //     it('should merge deeply nested project instances in correct order', () => {
+  //       icin.instances.unittest.deeper._strategy = 'replace';
+  //       result = jsonMerger(['defaults', 'instances']);
+  //
+  //       expect(result.instances.unittest).to.deep.equal({
+  //         a: dc.instances['*'].a,
+  //         b: dc.instances.unittest.b,
+  //         c: ic.instances['*'].c,
+  //         d: ic.instances.unittest.d,
+  //         x: [0, 1, 2, 3],
+  //         deeper: {
+  //           three: 3
+  //         }
+  //       });
+  //     });
+  //     it('should properly handle the replace strategy on environments', () => {
+  //       const files = ['defaults', 'instances', 'environments'];
+  //       ecin.prod.config._strategy = 'replace';
+  //
+  //       result = jsonMerger(files);
+  //       delete result.get;
+  //       delete result.set;
+  //
+  //       expect(result).to.deep.equal({
+  //         env: 'prod',
+  //         something: 'environments prod global something'
+  //       });
+  //     });
+  //     it('should properly handle the replace strategy on environment properties', () => {
+  //       const files = ['defaults', 'instances', 'environments'];
+  //       icin.testproperty = {
+  //         foo: 'bar'
+  //       };
+  //       ecin.prod.config.testproperty = {
+  //         _strategy: 'replace',
+  //         lorem: 'ipsum'
+  //       };
+  //
+  //       result = jsonMerger(files);
+  //       delete result.get;
+  //       delete result.set;
+  //
+  //       expect(result.testproperty).to.deep.equal({
+  //         lorem: 'ipsum'
+  //       });
+  //     });
+  //   });
+  //   describe('delete', () => {
+  //     it('should properly merge each instance with *', () => {
+  //       dcin.instances.unittest._strategy = 'delete';
+  //       result = jsonMerger(['defaults']);
+  //
+  //       expect(result.instances.unittest).to.be.undefined;
+  //     });
+  //     it('should properly merge the * instances', () => {
+  //       dcin.instances.tmptest = {};
+  //       icin.instances['*']._strategy = 'delete';
+  //       result = jsonMerger(['defaults', 'instances']);
+  //
+  //       expect(result.instances.tmptest).to.be.undefined;
+  //     });
+  //     it('should merge project instances in correct order (1)', () => {
+  //       dcin.instances.unittest._strategy = 'delete';
+  //       result = jsonMerger(['defaults', 'instances']);
+  //
+  //       expect(result.instances.unittest).to.deep.equal({
+  //         c: ic.instances['*'].c,
+  //         d: ic.instances.unittest.d,
+  //         x: [2, 3], // 0 and 1 were deleted, the rest was properly merged
+  //         deeper: {
+  //           two: 2,
+  //           three: 3
+  //         }
+  //       });
+  //     });
+  //     it('should merge project instances in correct order (2)', () => {
+  //       icin.instances.unittest._strategy = 'delete';
+  //       result = jsonMerger(['defaults', 'instances']);
+  //
+  //       expect(result.instances.unittest).to.be.undefined;
+  //     });
+  //     it('should properly merge objects from the highest level', () => {
+  //       icin._strategy = 'delete';
+  //       result = jsonMerger(['defaults', 'instances']);
+  //
+  //       expect(result).to.be.undefined;
+  //     });
+  //     it('should merge deeply nested project instances in correct order', () => {
+  //       icin.instances.unittest.deeper._strategy = 'delete';
+  //       result = jsonMerger(['defaults', 'instances']);
+  //
+  //       expect(result.instances.unittest.deeper).to.be.undefined;
+  //     });
+  //     it('should not delete null values when configured', () => {
+  //       dcin.instances.tmptest = {};
+  //       icin.instances['*']._strategy = 'delete';
+  //       result = jsonMerger(['defaults', 'instances'], {
+  //         deleteNullValues: false
+  //       });
+  //
+  //       expect(result.instances.tmptest).to.be.null;
+  //     });
+  //     it('should properly handle the delete strategy on environments', () => {
+  //       const files = ['defaults', 'instances', 'environments'];
+  //       ecin.prod.config._strategy = 'delete';
+  //
+  //       result = jsonMerger(files);
+  //       expect(result).to.be.undefined;
+  //     });
+  //     it('should properly handle the delete strategy on environment properties', () => {
+  //       const files = ['defaults', 'instances', 'environments'];
+  //       icin.testproperty = {
+  //         foo: 'bar'
+  //       };
+  //       ecin.prod.config.testproperty = {
+  //         _strategy: 'delete'
+  //       };
+  //
+  //       result = jsonMerger(files);
+  //       delete result.get;
+  //       delete result.set;
+  //
+  //       expect(result).not.to.have.property('testproperty');
+  //     });
+  //   });
+  // });
 });

--- a/test/jsonmerger.spec.js
+++ b/test/jsonmerger.spec.js
@@ -110,7 +110,7 @@ describe('jsonMerger', () => {
     icin = instancesConfig();
     ecin = environmentsConfig();
     jsonMerger = proxyquire('../lib/jsonmerger', {
-      os,
+      os: os,
       defaults: dcin,
       instances: icin,
       environments: ecin
@@ -183,7 +183,7 @@ describe('jsonMerger', () => {
         }
       };
       jsonMerger = proxyquire('../lib/jsonmerger', {
-        os,
+        os: os,
         defaults: dcin,
         instances: icin,
         environments: ecin
@@ -285,6 +285,50 @@ describe('jsonMerger', () => {
           five: 5
         }
       });
+    });
+    it('should properly merge arrays from nested wildcards when instances are configured in the default', () => {
+      dcin = {
+        level1: {
+          _instances: true,
+          '*': {
+            level2: {
+              _instances: true
+            }
+          }
+        }
+      };
+      icin = {
+        level1: {
+          '*': {
+            level2: {
+              '*': {
+                array: [
+                  'one',
+                ]
+              },
+              specific2: {
+                _strategy: 'noconcat',
+                array: [
+                  'two',
+                ]
+              }
+            }
+          },
+          specific1: {
+            level2: {
+              specific2: {}
+            }
+          }
+        }
+      };
+      jsonMerger = proxyquire('../lib/jsonmerger', {
+        os: os,
+        defaults: dcin,
+        instances: icin,
+        environments: ecin
+      });
+      result = jsonMerger(files);
+      expect(result.level1.specific1.level2.specific2.array).to.deep.equal(['two']);
     });
     it('should drop the `*` instance from the config', () => {
       result = jsonMerger(files);

--- a/test/jsonmerger.spec.js
+++ b/test/jsonmerger.spec.js
@@ -478,22 +478,6 @@ describe('jsonMerger', () => {
         }
       });
     });
-    it('should merge the wildcard properties of subsequent environments over current environment properties', () => {
-      os.hostname = sinon.stub().returns('devhost');
-
-      ecin.prod.config.instances = {
-        randomInstance: {
-          prop: null
-        }
-      };
-      ecin.dev.config.instances['*'].prop = 'foobar';
-
-      result = jsonMerger(files);
-      delete result.get;
-      delete result.set;
-
-      expect(result.instances.randomInstance.prop).to.deep.equal('foobar');
-    });
     it('should drop the `*` instance from the config', () => {
       result = jsonMerger(files);
       expect(Object.keys(result.instances)).to.have.length(1);

--- a/test/jsonmerger.spec.js
+++ b/test/jsonmerger.spec.js
@@ -189,7 +189,7 @@ describe('jsonMerger', () => {
         environments: ecin
       });
       result = jsonMerger(['instances']);
-      expect(result.level1.specific1.level2.specific2.array).to.equal(['two', 'three']);
+      expect(result.level1.specific1.level2.specific2.array).to.deep.equal(['two', 'three']);
     });
   });
   describe('with two (or more) regular config files', () => {

--- a/test/jsonmerger.spec.js
+++ b/test/jsonmerger.spec.js
@@ -333,6 +333,22 @@ describe('jsonMerger', function () {
         }
       });
     });
+    it('should merge the wildcard properties of subsequent environments over current environment properties', function () {
+      os.hostname = sinon.stub().returns('devhost');
+
+      ecin.prod.config.instances = {
+        randomInstance: {
+          prop: null
+        }
+      };
+      ecin.dev.config.instances['*'].prop = 'foobar';
+
+      result = jsonMerger(files);
+      delete result.get;
+      delete result.set;
+
+      expect(result.instances.randomInstance.prop).to.deep.equal('foobar');
+    });
     it('should drop the `*` instance from the config', function () {
       result = jsonMerger(files);
       expect(Object.keys(result.instances)).to.have.length(1);

--- a/test/jsonmerger.spec.js
+++ b/test/jsonmerger.spec.js
@@ -13,8 +13,8 @@ describe('jsonMerger', () => {
   let jsonMerger;
   let result;
   let dc;
-  // let ic;
-  // let ec;
+  let ic;
+  let ec;
   let dcin;
   let icin;
   let ecin;
@@ -24,7 +24,7 @@ describe('jsonMerger', () => {
       foo: 'default global foo',
       something: 'default global something',
       instances: {
-        _instances: true,
+        _instances: 'true',
         '*': {
           x: [0],
           a: 'default * a',
@@ -110,15 +110,15 @@ describe('jsonMerger', () => {
     icin = instancesConfig();
     ecin = environmentsConfig();
     jsonMerger = proxyquire('../lib/jsonmerger', {
-      os,
+      os: os,
       defaults: dcin,
       instances: icin,
       environments: ecin
     });
     // For easy result comparisons:
     dc = defaultConfig();
-    // ic = instancesConfig();
-    // ec = environmentsConfig();
+    ic = instancesConfig();
+    ec = environmentsConfig();
   });
   describe('with a single config file', () => {
     const files = ['defaults'];
@@ -183,7 +183,7 @@ describe('jsonMerger', () => {
         }
       };
       jsonMerger = proxyquire('../lib/jsonmerger', {
-        os,
+        os: os,
         defaults: dcin,
         instances: icin,
         environments: ecin
@@ -192,657 +192,657 @@ describe('jsonMerger', () => {
       expect(result.level1.specific1.level2.specific2.array).to.deep.equal(['two', 'three']);
     });
   });
-  // describe('with two (or more) regular config files', () => {
-  //   const files = ['defaults', 'instances'];
-  //   it('should merge global variables in order', () => {
-  //     result = jsonMerger(files);
-  //     expect(result.foo).to.deep.equal(dc.foo);
-  //     expect(result.something).to.deep.equal(ic.something);
-  //   });
-  //   it('should properly merge the * instances (1)', () => {
-  //     dcin.instances.tmptest = {};
-  //
-  //     result = jsonMerger(files);
-  //     expect(result.instances.tmptest).to.deep.equal({
-  //       a: dc.instances['*'].a,
-  //       b: dc.instances['*'].b,
-  //       c: ic.instances['*'].c,
-  //       d: ic.instances['*'].d,
-  //       x: [0, 2],
-  //       deeper: {
-  //         zero: 0,
-  //         two: 2
-  //       }
-  //     });
-  //   });
-  //   it('should properly merge the * instances (2)', () => {
-  //     icin.instances.tmptest = {};
-  //
-  //     result = jsonMerger(files);
-  //     expect(result.instances.tmptest).to.deep.equal({
-  //       a: dc.instances['*'].a,
-  //       b: dc.instances['*'].b,
-  //       c: ic.instances['*'].c,
-  //       d: ic.instances['*'].d,
-  //       x: [0, 2],
-  //       deeper: {
-  //         zero: 0,
-  //         two: 2
-  //       }
-  //     });
-  //   });
-  //   it('should properly merge nested * instances', () => {
-  //     dcin.instances['*'].subinstances = {
-  //       _instances: true,
-  //       '*': {
-  //         one: 1,
-  //         two: 2,
-  //         three: 3
-  //       },
-  //       instance: {
-  //         three: 33,
-  //         four: 4
-  //       },
-  //       emptyDefault: {}
-  //     };
-  //     icin.instances['*'].subinstances = {
-  //       '*': {
-  //         two: 22
-  //       },
-  //       instance: {
-  //         four: 44
-  //       },
-  //       newinstance: {
-  //         one: 11,
-  //         five: 5
-  //       },
-  //       emptyInstance: {}
-  //     };
-  //     icin.instances.tmptest = {};
-  //
-  //     result = jsonMerger(files);
-  //     expect(result.instances.tmptest.subinstances).to.deep.equal({
-  //       emptyDefault: {
-  //         one: 1,
-  //         two: 22,
-  //         three: 3
-  //       },
-  //       emptyInstance: {
-  //         one: 1,
-  //         two: 22,
-  //         three: 3
-  //       },
-  //       instance: {
-  //         one: 1,
-  //         two: 22,
-  //         three: 33,
-  //         four: 44
-  //       },
-  //       newinstance: {
-  //         one: 11,
-  //         two: 22,
-  //         three: 3,
-  //         five: 5
-  //       }
-  //     });
-  //   });
-  //   it('should properly merge arrays from nested wildcards when instances are configured in the default', () => {
-  //     dcin = {
-  //       level1: {
-  //         _instances: true,
-  //         '*': {
-  //           level2: {
-  //             _instances: true
-  //           }
-  //         }
-  //       }
-  //     };
-  //     icin = {
-  //       level1: {
-  //         '*': {
-  //           level2: {
-  //             '*': {
-  //               array: [
-  //                 'one',
-  //               ]
-  //             },
-  //             specific2: {
-  //               _strategy: 'noconcat',
-  //               array: [
-  //                 'two',
-  //               ]
-  //             }
-  //           }
-  //         },
-  //         specific1: {
-  //           level2: {
-  //             specific2: {}
-  //           }
-  //         }
-  //       }
-  //     };
-  //     jsonMerger = proxyquire('../lib/jsonmerger', {
-  //       os,
-  //       defaults: dcin,
-  //       instances: icin,
-  //       environments: ecin
-  //     });
-  //     result = jsonMerger(files);
-  //     expect(result.level1.specific1.level2.specific2.array).to.deep.equal(['two']);
-  //   });
-  //   it('should drop the `*` instance from the config', () => {
-  //     result = jsonMerger(files);
-  //     expect(Object.keys(result.instances)).to.have.length(1);
-  //     expect(result.instances).to.not.have.key('*');
-  //   });
-  //   it('should merge project instances in correct order', () => {
-  //     result = jsonMerger(files);
-  //     expect(result.instances.unittest).to.deep.equal({
-  //       a: dc.instances['*'].a,
-  //       b: dc.instances.unittest.b,
-  //       c: ic.instances['*'].c,
-  //       d: ic.instances.unittest.d,
-  //       x: [0, 1, 2, 3],
-  //       deeper: {
-  //         zero: 0,
-  //         one: 1,
-  //         two: 2,
-  //         three: 3
-  //       }
-  //     });
-  //   });
-  //   it('should add a getter and setter method to the result object', () => {
-  //     result = jsonMerger(files);
-  //     expect(result.get).to.be.a.function;
-  //     expect(result.set).to.be.a.function;
-  //   });
-  // });
-  // describe('with an environments config file', () => {
-  //   const files = ['defaults', 'instances', 'environments'];
-  //   it('should remove the preprocess directive when done', () => {
-  //     result = jsonMerger(files);
-  //     expect(ecin).to.not.have.keys('_preprocess');
-  //     expect(result).to.not.have.keys('_preprocess');
-  //   });
-  //   it('should properly merge the environments file based on host (1)', () => {
-  //     result = jsonMerger(files);
-  //     delete result.get;
-  //     delete result.set;
-  //
-  //     expect(result).to.deep.equal({
-  //       env: ec.prod.config.env,
-  //       foo: dc.foo,
-  //       something: ec.prod.config.something,
-  //       instances: {
-  //         unittest: {
-  //           a: dc.instances['*'].a,
-  //           b: dc.instances.unittest.b,
-  //           c: ic.instances['*'].c,
-  //           d: ic.instances.unittest.d,
-  //           x: [0, 1, 2, 3],
-  //           deeper: {
-  //             zero: 0,
-  //             one: 1,
-  //             two: 2,
-  //             three: 3
-  //           }
-  //         }
-  //       },
-  //     });
-  //   });
-  //   it('should properly merge the environments file based on host (2)', () => {
-  //     os.hostname = sinon.stub().returns('devhost');
-  //
-  //     result = jsonMerger(files);
-  //     delete result.get;
-  //     delete result.set;
-  //
-  //     expect(result).to.deep.equal({
-  //       env: ec.prod.config.env,
-  //       foo: dc.foo,
-  //       something: ec.prod.config.something,
-  //       instances: {
-  //         unittest: {
-  //           a: ec.dev.config.instances['*'].a,
-  //           b: dc.instances.unittest.b,
-  //           c: ic.instances['*'].c,
-  //           d: ic.instances.unittest.d,
-  //           x: [0, 1, 2, 3, 4],
-  //           deeper: {
-  //             zero: 0,
-  //             one: 1,
-  //             two: 2,
-  //             three: 3,
-  //             four: 4
-  //           }
-  //         }
-  //       }
-  //     });
-  //   });
-  //   it('should properly merge the environments file based on env variable (1)', () => {
-  //     process.env.NODE_ENV = 'prodenv';
-  //     os.hostname = sinon.stub().returns('localhost');
-  //
-  //     result = jsonMerger(files);
-  //     delete result.get;
-  //     delete result.set;
-  //
-  //     expect(result).to.deep.equal({
-  //       env: ec.prod.config.env,
-  //       foo: dc.foo,
-  //       something: ec.prod.config.something,
-  //       instances: {
-  //         unittest: {
-  //           a: dc.instances['*'].a,
-  //           b: dc.instances.unittest.b,
-  //           c: ic.instances['*'].c,
-  //           d: ic.instances.unittest.d,
-  //           x: [0, 1, 2, 3],
-  //           deeper: {
-  //             zero: 0,
-  //             one: 1,
-  //             two: 2,
-  //             three: 3
-  //           }
-  //         }
-  //       },
-  //     });
-  //   });
-  //   it('should properly merge the environments file based on env variable (2)', () => {
-  //     process.env.NODE_ENV = 'devenv';
-  //     os.hostname = sinon.stub().returns('localhost');
-  //
-  //     result = jsonMerger(files);
-  //     delete result.get;
-  //     delete result.set;
-  //
-  //     expect(result).to.deep.equal({
-  //       env: ec.prod.config.env,
-  //       foo: dc.foo,
-  //       something: ec.prod.config.something,
-  //       instances: {
-  //         unittest: {
-  //           a: ec.dev.config.instances['*'].a,
-  //           b: dc.instances.unittest.b,
-  //           c: ic.instances['*'].c,
-  //           d: ic.instances.unittest.d,
-  //           x: [0, 1, 2, 3, 4],
-  //           deeper: {
-  //             zero: 0,
-  //             one: 1,
-  //             two: 2,
-  //             three: 3,
-  //             four: 4
-  //           }
-  //         }
-  //       }
-  //     });
-  //   });
-  //   it('should drop the `*` instance from the config', () => {
-  //     result = jsonMerger(files);
-  //     expect(Object.keys(result.instances)).to.have.length(1);
-  //     expect(result.instances).to.not.have.key('*');
-  //   });
-  //   it('should add a getter and setter method to the result object', () => {
-  //     result = jsonMerger(files);
-  //     expect(result.get).to.be.a.function;
-  //     expect(result.set).to.be.a.function;
-  //   });
-  // });
-  // describe('using alternative merge strategy', () => {
-  //   describe('noconcat', () => {
-  //     it('should properly merge each instance with *', () => {
-  //       dcin.instances.unittest._strategy = 'noconcat';
-  //       result = jsonMerger(['defaults']);
-  //
-  //       expect(result.instances.unittest).to.deep.equal({
-  //         a: dc.instances['*'].a,
-  //         b: dc.instances.unittest.b,
-  //         c: dc.instances.unittest.c,
-  //         d: dc.instances.unittest.d,
-  //         x: [1],
-  //         deeper: {
-  //           zero: 0,
-  //           one: 1
-  //         }
-  //       });
-  //     });
-  //     it('should properly merge the * instances', () => {
-  //       dcin.instances.tmptest = {};
-  //       icin.instances['*']._strategy = 'noconcat';
-  //       result = jsonMerger(['defaults', 'instances']);
-  //
-  //       expect(result.instances.tmptest).to.deep.equal({
-  //         a: dc.instances['*'].a,
-  //         b: dc.instances['*'].b,
-  //         c: ic.instances['*'].c,
-  //         d: ic.instances['*'].d,
-  //         x: [2],
-  //         deeper: {
-  //           zero: 0,
-  //           two: 2
-  //         }
-  //       });
-  //     });
-  //     it('should merge project instances in correct order (1)', () => {
-  //       dcin.instances.unittest._strategy = 'noconcat';
-  //       result = jsonMerger(['defaults', 'instances']);
-  //
-  //       expect(result.instances.unittest).to.deep.equal({
-  //         a: dc.instances['*'].a,
-  //         b: dc.instances.unittest.b,
-  //         c: ic.instances['*'].c,
-  //         d: ic.instances.unittest.d,
-  //         x: [1, 2, 3], // 0 was replaced by 1, the rest was properly merged
-  //         deeper: {
-  //           zero: 0,
-  //           one: 1,
-  //           two: 2,
-  //           three: 3
-  //         }
-  //       });
-  //     });
-  //     it('should merge project instances in correct order (2)', () => {
-  //       icin.instances['*']._strategy = 'noconcat';
-  //       result = jsonMerger(['defaults', 'instances']);
-  //
-  //       expect(result.instances.unittest).to.deep.equal({
-  //         a: dc.instances['*'].a,
-  //         b: dc.instances.unittest.b,
-  //         c: ic.instances['*'].c,
-  //         d: ic.instances.unittest.d,
-  //         x: [2, 3], // [0,1] was replaced by 2, 3 was concatenated again afterwards
-  //         deeper: {
-  //           zero: 0,
-  //           one: 1,
-  //           two: 2,
-  //           three: 3
-  //         }
-  //       });
-  //     });
-  //     it('should merge project instances in correct order (3)', () => {
-  //       icin.instances.unittest._strategy = 'noconcat';
-  //       result = jsonMerger(['defaults', 'instances']);
-  //
-  //       expect(result.instances.unittest).to.deep.equal({
-  //         a: dc.instances['*'].a,
-  //         b: dc.instances.unittest.b,
-  //         c: ic.instances['*'].c,
-  //         d: ic.instances.unittest.d,
-  //         x: [3], // Full replace
-  //         deeper: {
-  //           zero: 0,
-  //           one: 1,
-  //           two: 2,
-  //           three: 3
-  //         }
-  //       });
-  //     });
-  //     it('should properly merge objects from the highest level', () => {
-  //       dcin.y = [0];
-  //       icin.y = [1];
-  //       icin._strategy = 'noconcat';
-  //       result = jsonMerger(['defaults', 'instances']);
-  //
-  //       expect(result.y).to.deep.equal([1]);
-  //       expect(result.instances.unittest).to.deep.equal({
-  //         a: dc.instances['*'].a,
-  //         b: dc.instances.unittest.b,
-  //         c: ic.instances['*'].c,
-  //         d: ic.instances.unittest.d,
-  //         x: [0, 1, 2, 3],
-  //         deeper: {
-  //           zero: 0,
-  //           one: 1,
-  //           two: 2,
-  //           three: 3,
-  //         }
-  //       });
-  //     });
-  //     it('should merge deeply nested project instances in correct order', () => {
-  //       dcin.instances.unittest.deeper.y = [0];
-  //       icin.instances.unittest.deeper.y = [1];
-  //       icin.instances.unittest.deeper._strategy = 'noconcat';
-  //       result = jsonMerger(['defaults', 'instances']);
-  //
-  //       expect(result.instances.unittest).to.deep.equal({
-  //         a: dc.instances['*'].a,
-  //         b: dc.instances.unittest.b,
-  //         c: ic.instances['*'].c,
-  //         d: ic.instances.unittest.d,
-  //         x: [0, 1, 2, 3], // Full replace
-  //         deeper: {
-  //           y: [1],
-  //           zero: 0,
-  //           one: 1,
-  //           two: 2,
-  //           three: 3
-  //         }
-  //       });
-  //     });
-  //     it('should properly handle the noconcat strategy on environments', () => {
-  //       const files = ['defaults', 'instances', 'environments'];
-  //       dcin.testproperty = ['foo'];
-  //       icin.testproperty = ['bar'];
-  //       ecin.prod.config = {
-  //         _strategy: 'noconcat',
-  //         testproperty: ['lorem']
-  //       };
-  //
-  //       result = jsonMerger(files);
-  //       delete result.get;
-  //       delete result.set;
-  //
-  //       expect(result.testproperty).to.deep.equal(['lorem']);
-  //     });
-  //   });
-  //   describe('replace', () => {
-  //     it('should properly merge each instance with *', () => {
-  //       dcin.instances.unittest._strategy = 'replace';
-  //       result = jsonMerger(['defaults']);
-  //
-  //       expect(result.instances.unittest).to.deep.equal({
-  //         b: dc.instances.unittest.b,
-  //         c: dc.instances.unittest.c,
-  //         d: dc.instances.unittest.d,
-  //         x: [1],
-  //         deeper: {
-  //           one: 1
-  //         }
-  //       });
-  //     });
-  //     it('should properly merge the * instances', () => {
-  //       dcin.instances.tmptest = {};
-  //       icin.instances['*']._strategy = 'replace';
-  //       result = jsonMerger(['defaults', 'instances']);
-  //
-  //       expect(result.instances.tmptest).to.deep.equal({
-  //         c: ic.instances['*'].c,
-  //         d: ic.instances['*'].d,
-  //         x: [2],
-  //         deeper: {
-  //           two: 2
-  //         }
-  //       });
-  //     });
-  //     it('should merge project instances in correct order (1)', () => {
-  //       dcin.instances.unittest._strategy = 'replace';
-  //       result = jsonMerger(['defaults', 'instances']);
-  //
-  //       expect(result.instances.unittest).to.deep.equal({
-  //         b: dc.instances.unittest.b,
-  //         c: ic.instances['*'].c,
-  //         d: ic.instances.unittest.d,
-  //         x: [1, 2, 3], // 0 was replaced by 1, the rest was properly merged
-  //         deeper: {
-  //           one: 1,
-  //           two: 2,
-  //           three: 3
-  //         }
-  //       });
-  //     });
-  //     it('should merge project instances in correct order (2)', () => {
-  //       icin.instances.unittest._strategy = 'replace';
-  //       result = jsonMerger(['defaults', 'instances']);
-  //
-  //       expect(result.instances.unittest).to.deep.equal({
-  //         x: [3],
-  //         d: 'instances unittest d',
-  //         deeper: {
-  //           three: 3
-  //         }
-  //       });
-  //     });
-  //     it('should properly merge objects from the highest level', () => {
-  //       dcin.someObject = {
-  //         foo: 'foo'
-  //       };
-  //       icin.someObject = {
-  //         bar: 'bar'
-  //       };
-  //       icin._strategy = 'replace';
-  //       // It's important we define the new `_instances` directive again since
-  //       // the "old" one will never be read by the `replace` strategy.
-  //       icin.instances._instances = true;
-  //       result = jsonMerger(['defaults', 'instances']);
-  //
-  //       expect(result.someObject).to.deep.equal({
-  //         bar: 'bar'
-  //       });
-  //       expect(result.instances.unittest).to.deep.equal({
-  //         c: ic.instances['*'].c,
-  //         d: ic.instances.unittest.d,
-  //         x: [2, 3],
-  //         deeper: {
-  //           two: 2,
-  //           three: 3
-  //         }
-  //       });
-  //     });
-  //     it('should merge deeply nested project instances in correct order', () => {
-  //       icin.instances.unittest.deeper._strategy = 'replace';
-  //       result = jsonMerger(['defaults', 'instances']);
-  //
-  //       expect(result.instances.unittest).to.deep.equal({
-  //         a: dc.instances['*'].a,
-  //         b: dc.instances.unittest.b,
-  //         c: ic.instances['*'].c,
-  //         d: ic.instances.unittest.d,
-  //         x: [0, 1, 2, 3],
-  //         deeper: {
-  //           three: 3
-  //         }
-  //       });
-  //     });
-  //     it('should properly handle the replace strategy on environments', () => {
-  //       const files = ['defaults', 'instances', 'environments'];
-  //       ecin.prod.config._strategy = 'replace';
-  //
-  //       result = jsonMerger(files);
-  //       delete result.get;
-  //       delete result.set;
-  //
-  //       expect(result).to.deep.equal({
-  //         env: 'prod',
-  //         something: 'environments prod global something'
-  //       });
-  //     });
-  //     it('should properly handle the replace strategy on environment properties', () => {
-  //       const files = ['defaults', 'instances', 'environments'];
-  //       icin.testproperty = {
-  //         foo: 'bar'
-  //       };
-  //       ecin.prod.config.testproperty = {
-  //         _strategy: 'replace',
-  //         lorem: 'ipsum'
-  //       };
-  //
-  //       result = jsonMerger(files);
-  //       delete result.get;
-  //       delete result.set;
-  //
-  //       expect(result.testproperty).to.deep.equal({
-  //         lorem: 'ipsum'
-  //       });
-  //     });
-  //   });
-  //   describe('delete', () => {
-  //     it('should properly merge each instance with *', () => {
-  //       dcin.instances.unittest._strategy = 'delete';
-  //       result = jsonMerger(['defaults']);
-  //
-  //       expect(result.instances.unittest).to.be.undefined;
-  //     });
-  //     it('should properly merge the * instances', () => {
-  //       dcin.instances.tmptest = {};
-  //       icin.instances['*']._strategy = 'delete';
-  //       result = jsonMerger(['defaults', 'instances']);
-  //
-  //       expect(result.instances.tmptest).to.be.undefined;
-  //     });
-  //     it('should merge project instances in correct order (1)', () => {
-  //       dcin.instances.unittest._strategy = 'delete';
-  //       result = jsonMerger(['defaults', 'instances']);
-  //
-  //       expect(result.instances.unittest).to.deep.equal({
-  //         c: ic.instances['*'].c,
-  //         d: ic.instances.unittest.d,
-  //         x: [2, 3], // 0 and 1 were deleted, the rest was properly merged
-  //         deeper: {
-  //           two: 2,
-  //           three: 3
-  //         }
-  //       });
-  //     });
-  //     it('should merge project instances in correct order (2)', () => {
-  //       icin.instances.unittest._strategy = 'delete';
-  //       result = jsonMerger(['defaults', 'instances']);
-  //
-  //       expect(result.instances.unittest).to.be.undefined;
-  //     });
-  //     it('should properly merge objects from the highest level', () => {
-  //       icin._strategy = 'delete';
-  //       result = jsonMerger(['defaults', 'instances']);
-  //
-  //       expect(result).to.be.undefined;
-  //     });
-  //     it('should merge deeply nested project instances in correct order', () => {
-  //       icin.instances.unittest.deeper._strategy = 'delete';
-  //       result = jsonMerger(['defaults', 'instances']);
-  //
-  //       expect(result.instances.unittest.deeper).to.be.undefined;
-  //     });
-  //     it('should not delete null values when configured', () => {
-  //       dcin.instances.tmptest = {};
-  //       icin.instances['*']._strategy = 'delete';
-  //       result = jsonMerger(['defaults', 'instances'], {
-  //         deleteNullValues: false
-  //       });
-  //
-  //       expect(result.instances.tmptest).to.be.null;
-  //     });
-  //     it('should properly handle the delete strategy on environments', () => {
-  //       const files = ['defaults', 'instances', 'environments'];
-  //       ecin.prod.config._strategy = 'delete';
-  //
-  //       result = jsonMerger(files);
-  //       expect(result).to.be.undefined;
-  //     });
-  //     it('should properly handle the delete strategy on environment properties', () => {
-  //       const files = ['defaults', 'instances', 'environments'];
-  //       icin.testproperty = {
-  //         foo: 'bar'
-  //       };
-  //       ecin.prod.config.testproperty = {
-  //         _strategy: 'delete'
-  //       };
-  //
-  //       result = jsonMerger(files);
-  //       delete result.get;
-  //       delete result.set;
-  //
-  //       expect(result).not.to.have.property('testproperty');
-  //     });
-  //   });
-  // });
+  describe('with two (or more) regular config files', () => {
+    const files = ['defaults', 'instances'];
+    it('should merge global variables in order', () => {
+      result = jsonMerger(files);
+      expect(result.foo).to.deep.equal(dc.foo);
+      expect(result.something).to.deep.equal(ic.something);
+    });
+    it('should properly merge the * instances (1)', () => {
+      dcin.instances.tmptest = {};
+
+      result = jsonMerger(files);
+      expect(result.instances.tmptest).to.deep.equal({
+        a: dc.instances['*'].a,
+        b: dc.instances['*'].b,
+        c: ic.instances['*'].c,
+        d: ic.instances['*'].d,
+        x: [0, 2],
+        deeper: {
+          zero: 0,
+          two: 2
+        }
+      });
+    });
+    it('should properly merge the * instances (2)', () => {
+      icin.instances.tmptest = {};
+
+      result = jsonMerger(files);
+      expect(result.instances.tmptest).to.deep.equal({
+        a: dc.instances['*'].a,
+        b: dc.instances['*'].b,
+        c: ic.instances['*'].c,
+        d: ic.instances['*'].d,
+        x: [0, 2],
+        deeper: {
+          zero: 0,
+          two: 2
+        }
+      });
+    });
+    it('should properly merge nested * instances', () => {
+      dcin.instances['*'].subinstances = {
+        _instances: true,
+        '*': {
+          one: 1,
+          two: 2,
+          three: 3
+        },
+        instance: {
+          three: 33,
+          four: 4
+        },
+        emptyDefault: {}
+      };
+      icin.instances['*'].subinstances = {
+        '*': {
+          two: 22
+        },
+        instance: {
+          four: 44
+        },
+        newinstance: {
+          one: 11,
+          five: 5
+        },
+        emptyInstance: {}
+      };
+      icin.instances.tmptest = {};
+
+      result = jsonMerger(files);
+      expect(result.instances.tmptest.subinstances).to.deep.equal({
+        emptyDefault: {
+          one: 1,
+          two: 22,
+          three: 3
+        },
+        emptyInstance: {
+          one: 1,
+          two: 22,
+          three: 3
+        },
+        instance: {
+          one: 1,
+          two: 22,
+          three: 33,
+          four: 44
+        },
+        newinstance: {
+          one: 11,
+          two: 22,
+          three: 3,
+          five: 5
+        }
+      });
+    });
+    it('should properly merge arrays from nested wildcards when instances are configured in the default', () => {
+      dcin = {
+        level1: {
+          _instances: true,
+          '*': {
+            level2: {
+              _instances: true
+            }
+          }
+        }
+      };
+      icin = {
+        level1: {
+          '*': {
+            level2: {
+              '*': {
+                array: [
+                  'one',
+                ]
+              },
+              specific2: {
+                _strategy: 'noconcat',
+                array: [
+                  'two',
+                ]
+              }
+            }
+          },
+          specific1: {
+            level2: {
+              specific2: {}
+            }
+          }
+        }
+      };
+      jsonMerger = proxyquire('../lib/jsonmerger', {
+        os: os,
+        defaults: dcin,
+        instances: icin,
+        environments: ecin
+      });
+      result = jsonMerger(files);
+      expect(result.level1.specific1.level2.specific2.array).to.deep.equal(['two']);
+    });
+    it('should drop the `*` instance from the config', () => {
+      result = jsonMerger(files);
+      expect(Object.keys(result.instances)).to.have.length(1);
+      expect(result.instances).to.not.have.key('*');
+    });
+    it('should merge project instances in correct order', () => {
+      result = jsonMerger(files);
+      expect(result.instances.unittest).to.deep.equal({
+        a: dc.instances['*'].a,
+        b: dc.instances.unittest.b,
+        c: ic.instances['*'].c,
+        d: ic.instances.unittest.d,
+        x: [0, 1, 2, 3],
+        deeper: {
+          zero: 0,
+          one: 1,
+          two: 2,
+          three: 3
+        }
+      });
+    });
+    it('should add a getter and setter method to the result object', () => {
+      result = jsonMerger(files);
+      expect(result.get).to.be.a.function;
+      expect(result.set).to.be.a.function;
+    });
+  });
+  describe('with an environments config file', () => {
+    const files = ['defaults', 'instances', 'environments'];
+    it('should remove the preprocess directive when done', () => {
+      result = jsonMerger(files);
+      expect(ecin).to.not.have.keys('_preprocess');
+      expect(result).to.not.have.keys('_preprocess');
+    });
+    it('should properly merge the environments file based on host (1)', () => {
+      result = jsonMerger(files);
+      delete result.get;
+      delete result.set;
+
+      expect(result).to.deep.equal({
+        env: ec.prod.config.env,
+        foo: dc.foo,
+        something: ec.prod.config.something,
+        instances: {
+          unittest: {
+            a: dc.instances['*'].a,
+            b: dc.instances.unittest.b,
+            c: ic.instances['*'].c,
+            d: ic.instances.unittest.d,
+            x: [0, 1, 2, 3],
+            deeper: {
+              zero: 0,
+              one: 1,
+              two: 2,
+              three: 3
+            }
+          }
+        },
+      });
+    });
+    it('should properly merge the environments file based on host (2)', () => {
+      os.hostname = sinon.stub().returns('devhost');
+
+      result = jsonMerger(files);
+      delete result.get;
+      delete result.set;
+
+      expect(result).to.deep.equal({
+        env: ec.prod.config.env,
+        foo: dc.foo,
+        something: ec.prod.config.something,
+        instances: {
+          unittest: {
+            a: ec.dev.config.instances['*'].a,
+            b: dc.instances.unittest.b,
+            c: ic.instances['*'].c,
+            d: ic.instances.unittest.d,
+            x: [0, 1, 2, 3, 4],
+            deeper: {
+              zero: 0,
+              one: 1,
+              two: 2,
+              three: 3,
+              four: 4
+            }
+          }
+        }
+      });
+    });
+    it('should properly merge the environments file based on env variable (1)', () => {
+      process.env.NODE_ENV = 'prodenv';
+      os.hostname = sinon.stub().returns('localhost');
+
+      result = jsonMerger(files);
+      delete result.get;
+      delete result.set;
+
+      expect(result).to.deep.equal({
+        env: ec.prod.config.env,
+        foo: dc.foo,
+        something: ec.prod.config.something,
+        instances: {
+          unittest: {
+            a: dc.instances['*'].a,
+            b: dc.instances.unittest.b,
+            c: ic.instances['*'].c,
+            d: ic.instances.unittest.d,
+            x: [0, 1, 2, 3],
+            deeper: {
+              zero: 0,
+              one: 1,
+              two: 2,
+              three: 3
+            }
+          }
+        },
+      });
+    });
+    it('should properly merge the environments file based on env variable (2)', () => {
+      process.env.NODE_ENV = 'devenv';
+      os.hostname = sinon.stub().returns('localhost');
+
+      result = jsonMerger(files);
+      delete result.get;
+      delete result.set;
+
+      expect(result).to.deep.equal({
+        env: ec.prod.config.env,
+        foo: dc.foo,
+        something: ec.prod.config.something,
+        instances: {
+          unittest: {
+            a: ec.dev.config.instances['*'].a,
+            b: dc.instances.unittest.b,
+            c: ic.instances['*'].c,
+            d: ic.instances.unittest.d,
+            x: [0, 1, 2, 3, 4],
+            deeper: {
+              zero: 0,
+              one: 1,
+              two: 2,
+              three: 3,
+              four: 4
+            }
+          }
+        }
+      });
+    });
+    it('should drop the `*` instance from the config', () => {
+      result = jsonMerger(files);
+      expect(Object.keys(result.instances)).to.have.length(1);
+      expect(result.instances).to.not.have.key('*');
+    });
+    it('should add a getter and setter method to the result object', () => {
+      result = jsonMerger(files);
+      expect(result.get).to.be.a.function;
+      expect(result.set).to.be.a.function;
+    });
+  });
+  describe('using alternative merge strategy', () => {
+    describe('noconcat', () => {
+      it('should properly merge each instance with *', () => {
+        dcin.instances.unittest._strategy = 'noconcat';
+        result = jsonMerger(['defaults']);
+
+        expect(result.instances.unittest).to.deep.equal({
+          a: dc.instances['*'].a,
+          b: dc.instances.unittest.b,
+          c: dc.instances.unittest.c,
+          d: dc.instances.unittest.d,
+          x: [1],
+          deeper: {
+            zero: 0,
+            one: 1
+          }
+        });
+      });
+      it('should properly merge the * instances', () => {
+        dcin.instances.tmptest = {};
+        icin.instances['*']._strategy = 'noconcat';
+        result = jsonMerger(['defaults', 'instances']);
+
+        expect(result.instances.tmptest).to.deep.equal({
+          a: dc.instances['*'].a,
+          b: dc.instances['*'].b,
+          c: ic.instances['*'].c,
+          d: ic.instances['*'].d,
+          x: [2],
+          deeper: {
+            zero: 0,
+            two: 2
+          }
+        });
+      });
+      it('should merge project instances in correct order (1)', () => {
+        dcin.instances.unittest._strategy = 'noconcat';
+        result = jsonMerger(['defaults', 'instances']);
+
+        expect(result.instances.unittest).to.deep.equal({
+          a: dc.instances['*'].a,
+          b: dc.instances.unittest.b,
+          c: ic.instances['*'].c,
+          d: ic.instances.unittest.d,
+          x: [1, 2, 3], // 0 was replaced by 1, the rest was properly merged
+          deeper: {
+            zero: 0,
+            one: 1,
+            two: 2,
+            three: 3
+          }
+        });
+      });
+      it('should merge project instances in correct order (2)', () => {
+        icin.instances['*']._strategy = 'noconcat';
+        result = jsonMerger(['defaults', 'instances']);
+
+        expect(result.instances.unittest).to.deep.equal({
+          a: dc.instances['*'].a,
+          b: dc.instances.unittest.b,
+          c: ic.instances['*'].c,
+          d: ic.instances.unittest.d,
+          x: [2, 3], // [0,1] was replaced by 2, 3 was concatenated again afterwards
+          deeper: {
+            zero: 0,
+            one: 1,
+            two: 2,
+            three: 3
+          }
+        });
+      });
+      it('should merge project instances in correct order (3)', () => {
+        icin.instances.unittest._strategy = 'noconcat';
+        result = jsonMerger(['defaults', 'instances']);
+
+        expect(result.instances.unittest).to.deep.equal({
+          a: dc.instances['*'].a,
+          b: dc.instances.unittest.b,
+          c: ic.instances['*'].c,
+          d: ic.instances.unittest.d,
+          x: [3], // Full replace
+          deeper: {
+            zero: 0,
+            one: 1,
+            two: 2,
+            three: 3
+          }
+        });
+      });
+      it('should properly merge objects from the highest level', () => {
+        dcin.y = [0];
+        icin.y = [1];
+        icin._strategy = 'noconcat';
+        result = jsonMerger(['defaults', 'instances']);
+
+        expect(result.y).to.deep.equal([1]);
+        expect(result.instances.unittest).to.deep.equal({
+          a: dc.instances['*'].a,
+          b: dc.instances.unittest.b,
+          c: ic.instances['*'].c,
+          d: ic.instances.unittest.d,
+          x: [0, 1, 2, 3],
+          deeper: {
+            zero: 0,
+            one: 1,
+            two: 2,
+            three: 3,
+          }
+        });
+      });
+      it('should merge deeply nested project instances in correct order', () => {
+        dcin.instances.unittest.deeper.y = [0];
+        icin.instances.unittest.deeper.y = [1];
+        icin.instances.unittest.deeper._strategy = 'noconcat';
+        result = jsonMerger(['defaults', 'instances']);
+
+        expect(result.instances.unittest).to.deep.equal({
+          a: dc.instances['*'].a,
+          b: dc.instances.unittest.b,
+          c: ic.instances['*'].c,
+          d: ic.instances.unittest.d,
+          x: [0, 1, 2, 3], // Full replace
+          deeper: {
+            y: [1],
+            zero: 0,
+            one: 1,
+            two: 2,
+            three: 3
+          }
+        });
+      });
+      it('should properly handle the noconcat strategy on environments', () => {
+        const files = ['defaults', 'instances', 'environments'];
+        dcin.testproperty = ['foo'];
+        icin.testproperty = ['bar'];
+        ecin.prod.config = {
+          _strategy: 'noconcat',
+          testproperty: ['lorem']
+        };
+
+        result = jsonMerger(files);
+        delete result.get;
+        delete result.set;
+
+        expect(result.testproperty).to.deep.equal(['lorem']);
+      });
+    });
+    describe('replace', () => {
+      it('should properly merge each instance with *', () => {
+        dcin.instances.unittest._strategy = 'replace';
+        result = jsonMerger(['defaults']);
+
+        expect(result.instances.unittest).to.deep.equal({
+          b: dc.instances.unittest.b,
+          c: dc.instances.unittest.c,
+          d: dc.instances.unittest.d,
+          x: [1],
+          deeper: {
+            one: 1
+          }
+        });
+      });
+      it('should properly merge the * instances', () => {
+        dcin.instances.tmptest = {};
+        icin.instances['*']._strategy = 'replace';
+        result = jsonMerger(['defaults', 'instances']);
+
+        expect(result.instances.tmptest).to.deep.equal({
+          c: ic.instances['*'].c,
+          d: ic.instances['*'].d,
+          x: [2],
+          deeper: {
+            two: 2
+          }
+        });
+      });
+      it('should merge project instances in correct order (1)', () => {
+        dcin.instances.unittest._strategy = 'replace';
+        result = jsonMerger(['defaults', 'instances']);
+
+        expect(result.instances.unittest).to.deep.equal({
+          b: dc.instances.unittest.b,
+          c: ic.instances['*'].c,
+          d: ic.instances.unittest.d,
+          x: [1, 2, 3], // 0 was replaced by 1, the rest was properly merged
+          deeper: {
+            one: 1,
+            two: 2,
+            three: 3
+          }
+        });
+      });
+      it('should merge project instances in correct order (2)', () => {
+        icin.instances.unittest._strategy = 'replace';
+        result = jsonMerger(['defaults', 'instances']);
+
+        expect(result.instances.unittest).to.deep.equal({
+          x: [3],
+          d: 'instances unittest d',
+          deeper: {
+            three: 3
+          }
+        });
+      });
+      it('should properly merge objects from the highest level', () => {
+        dcin.someObject = {
+          foo: 'foo'
+        };
+        icin.someObject = {
+          bar: 'bar'
+        };
+        icin._strategy = 'replace';
+        // It's important we define the new `_instances` directive again since
+        // the "old" one will never be read by the `replace` strategy.
+        icin.instances._instances = true;
+        result = jsonMerger(['defaults', 'instances']);
+
+        expect(result.someObject).to.deep.equal({
+          bar: 'bar'
+        });
+        expect(result.instances.unittest).to.deep.equal({
+          c: ic.instances['*'].c,
+          d: ic.instances.unittest.d,
+          x: [2, 3],
+          deeper: {
+            two: 2,
+            three: 3
+          }
+        });
+      });
+      it('should merge deeply nested project instances in correct order', () => {
+        icin.instances.unittest.deeper._strategy = 'replace';
+        result = jsonMerger(['defaults', 'instances']);
+
+        expect(result.instances.unittest).to.deep.equal({
+          a: dc.instances['*'].a,
+          b: dc.instances.unittest.b,
+          c: ic.instances['*'].c,
+          d: ic.instances.unittest.d,
+          x: [0, 1, 2, 3],
+          deeper: {
+            three: 3
+          }
+        });
+      });
+      it('should properly handle the replace strategy on environments', () => {
+        const files = ['defaults', 'instances', 'environments'];
+        ecin.prod.config._strategy = 'replace';
+
+        result = jsonMerger(files);
+        delete result.get;
+        delete result.set;
+
+        expect(result).to.deep.equal({
+          env: 'prod',
+          something: 'environments prod global something'
+        });
+      });
+      it('should properly handle the replace strategy on environment properties', () => {
+        const files = ['defaults', 'instances', 'environments'];
+        icin.testproperty = {
+          foo: 'bar'
+        };
+        ecin.prod.config.testproperty = {
+          _strategy: 'replace',
+          lorem: 'ipsum'
+        };
+
+        result = jsonMerger(files);
+        delete result.get;
+        delete result.set;
+
+        expect(result.testproperty).to.deep.equal({
+          lorem: 'ipsum'
+        });
+      });
+    });
+    describe('delete', () => {
+      it('should properly merge each instance with *', () => {
+        dcin.instances.unittest._strategy = 'delete';
+        result = jsonMerger(['defaults']);
+
+        expect(result.instances.unittest).to.be.undefined;
+      });
+      it('should properly merge the * instances', () => {
+        dcin.instances.tmptest = {};
+        icin.instances['*']._strategy = 'delete';
+        result = jsonMerger(['defaults', 'instances']);
+
+        expect(result.instances.tmptest).to.be.undefined;
+      });
+      it('should merge project instances in correct order (1)', () => {
+        dcin.instances.unittest._strategy = 'delete';
+        result = jsonMerger(['defaults', 'instances']);
+
+        expect(result.instances.unittest).to.deep.equal({
+          c: ic.instances['*'].c,
+          d: ic.instances.unittest.d,
+          x: [2, 3], // 0 and 1 were deleted, the rest was properly merged
+          deeper: {
+            two: 2,
+            three: 3
+          }
+        });
+      });
+      it('should merge project instances in correct order (2)', () => {
+        icin.instances.unittest._strategy = 'delete';
+        result = jsonMerger(['defaults', 'instances']);
+
+        expect(result.instances.unittest).to.be.undefined;
+      });
+      it('should properly merge objects from the highest level', () => {
+        icin._strategy = 'delete';
+        result = jsonMerger(['defaults', 'instances']);
+
+        expect(result).to.be.undefined;
+      });
+      it('should merge deeply nested project instances in correct order', () => {
+        icin.instances.unittest.deeper._strategy = 'delete';
+        result = jsonMerger(['defaults', 'instances']);
+
+        expect(result.instances.unittest.deeper).to.be.undefined;
+      });
+      it('should not delete null values when configured', () => {
+        dcin.instances.tmptest = {};
+        icin.instances['*']._strategy = 'delete';
+        result = jsonMerger(['defaults', 'instances'], {
+          deleteNullValues: false
+        });
+
+        expect(result.instances.tmptest).to.be.null;
+      });
+      it('should properly handle the delete strategy on environments', () => {
+        const files = ['defaults', 'instances', 'environments'];
+        ecin.prod.config._strategy = 'delete';
+
+        result = jsonMerger(files);
+        expect(result).to.be.undefined;
+      });
+      it('should properly handle the delete strategy on environment properties', () => {
+        const files = ['defaults', 'instances', 'environments'];
+        icin.testproperty = {
+          foo: 'bar'
+        };
+        ecin.prod.config.testproperty = {
+          _strategy: 'delete'
+        };
+
+        result = jsonMerger(files);
+        delete result.get;
+        delete result.set;
+
+        expect(result).not.to.have.property('testproperty');
+      });
+    });
+  });
 });

--- a/test/jsonmerger.spec.js
+++ b/test/jsonmerger.spec.js
@@ -151,6 +151,46 @@ describe('jsonMerger', () => {
       expect(result.get).to.be.a.function;
       expect(result.set).to.be.a.function;
     });
+    it('should properly merge arrays from nested wildcards', () => {
+      icin = {
+        level1: {
+          _instances: true,
+          '*': {
+            level2: {
+              _instances: true,
+              '*': {
+                array: [
+                  'one',
+                ]
+              },
+              specific2: {
+                _strategy: 'noconcat',
+                array: [
+                  'two',
+                ]
+              }
+            }
+          },
+          specific1: {
+            level2: {
+              specific2: {
+                array: [
+                  'three'
+                ]
+              }
+            }
+          }
+        }
+      };
+      jsonMerger = proxyquire('../lib/jsonmerger', {
+        os: os,
+        defaults: dcin,
+        instances: icin,
+        environments: ecin
+      });
+      result = jsonMerger(['instances']);
+      expect(result.level1.specific1.level2.specific2.array).to.equal(['two', 'three']);
+    });
   });
   describe('with two (or more) regular config files', () => {
     const files = ['defaults', 'instances'];

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,8 +21,8 @@ ajv-keywords@^1.0.0:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
 
 ajv@^4.7.0:
-  version "4.11.5"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.5.tgz#b6ee74657b993a01dce44b7944d56f485828d5bd"
+  version "4.11.6"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.6.tgz#947e93049790942b2a2d60a8289b28924d39f987"
   dependencies:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
@@ -76,8 +76,8 @@ balanced-match@^0.4.1:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
 
 brace-expansion@^1.0.0:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.6.tgz#7197d7eaa9b87e648390ea61fc66c84427420df9"
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.7.tgz#3effc3c50e000531fb720eaff80f0ae8ef23cf59"
   dependencies:
     balanced-match "^0.4.1"
     concat-map "0.0.1"
@@ -86,7 +86,7 @@ browser-stdout@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
 
-buffer-shims@^1.0.0:
+buffer-shims@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
 
@@ -168,17 +168,11 @@ d@1:
   dependencies:
     es5-ext "^0.10.9"
 
-debug@2.2.0:
+debug@2.2.0, debug@^2.1.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
   dependencies:
     ms "0.7.1"
-
-debug@^2.1.1:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.3.tgz#0f7eb8c30965ec08c72accfa0130c8b79984141d"
-  dependencies:
-    ms "0.7.2"
 
 deep-eql@^0.1.3:
   version "0.1.3"
@@ -289,9 +283,11 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-config-mm@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-config-mm/-/eslint-config-mm-1.1.1.tgz#ab2ba90b5b6a88253a16b5f875204534f305fa37"
+eslint-config-mm@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-mm/-/eslint-config-mm-1.2.0.tgz#42d6a5b6d02e56fdc363d99cd79b9be540e5bff6"
+  dependencies:
+    eslint "^3.19.0"
 
 eslint@^3.19.0:
   version "3.19.0"
@@ -434,20 +430,9 @@ generate-object-property@^1.1.0:
   dependencies:
     is-property "^1.0.0"
 
-glob@7.0.5:
+glob@7.0.5, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.0.5.tgz#b4202a69099bbb4d292a7c1b95b6682b67ebdc95"
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.2"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -494,8 +479,8 @@ has-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
 
 ignore@^3.2.0:
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.2.6.tgz#26e8da0644be0bb4cb39516f6c79f0e0f4ffe48c"
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.2.7.tgz#4810ca5f1d8eca5595213a34b94f2eb4ed926bbd"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -726,10 +711,6 @@ ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
 
-ms@0.7.2:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
-
 mute-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
@@ -828,15 +809,15 @@ proxyquire@^1.7.11:
     resolve "~1.1.7"
 
 readable-stream@^2.2.2:
-  version "2.2.6"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.6.tgz#8b43aed76e71483938d12a8d46c6cf1a00b1f816"
+  version "2.2.9"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.9.tgz#cf78ec6f4a6d1eb43d26488cac97f042e74b7fc8"
   dependencies:
-    buffer-shims "^1.0.0"
+    buffer-shims "~1.0.0"
     core-util-is "~1.0.0"
     inherits "~2.0.1"
     isarray "~1.0.0"
     process-nextick-args "~1.0.6"
-    string_decoder "~0.10.x"
+    string_decoder "~1.0.0"
     util-deprecate "~1.0.1"
 
 readline2@^1.0.1:
@@ -943,9 +924,11 @@ string-width@^2.0.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^3.0.0"
 
-string_decoder@~0.10.x:
-  version "0.10.31"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
+string_decoder@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.0.tgz#f06f41157b664d86069f84bdbdc9b0d8ab281667"
+  dependencies:
+    buffer-shims "~1.0.0"
 
 strip-ansi@^3.0.0:
   version "3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,21 +8,21 @@ acorn-jsx@^3.0.0:
   dependencies:
     acorn "^3.0.4"
 
-acorn@4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.4.tgz#17a8d6a7a6c4ef538b814ec9abac2779293bf30a"
-
 acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
+
+acorn@^5.0.1:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.0.3.tgz#c460df08491463f028ccb82eab3730bf01087b3d"
 
 ajv-keywords@^1.0.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
 
 ajv@^4.7.0:
-  version "4.11.4"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.4.tgz#ebf3a55d4b132ea60ff5847ae85d2ef069960b45"
+  version "4.11.5"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.5.tgz#b6ee74657b993a01dce44b7944d56f485828d5bd"
   dependencies:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
@@ -82,6 +82,10 @@ brace-expansion@^1.0.0:
     balanced-match "^0.4.1"
     concat-map "0.0.1"
 
+browser-stdout@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
+
 buffer-shims@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
@@ -96,7 +100,7 @@ callsites@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
 
-chai@^3.4.1:
+chai@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/chai/-/chai-3.5.0.tgz#4d02637b067fe958bdbfdd3a40ec56fef7373247"
   dependencies:
@@ -136,19 +140,17 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
-commander@0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-0.6.1.tgz#fa68a14f6a945d54dbbe50d8cdb3320e9e3b1a06"
-
-commander@2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.3.0.tgz#fd430e889832ec353b9acd1de217c11cb3eef873"
+commander@2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
+  dependencies:
+    graceful-readlink ">= 1.0.0"
 
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.4.6:
+concat-stream@^1.5.2:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
@@ -160,11 +162,11 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-d@^0.1.1, d@~0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/d/-/d-0.1.1.tgz#da184c535d18d8ee7ba2aa229b914009fae11309"
+d@1:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
   dependencies:
-    es5-ext "~0.10.2"
+    es5-ext "^0.10.9"
 
 debug@2.2.0:
   version "2.2.0"
@@ -173,8 +175,8 @@ debug@2.2.0:
     ms "0.7.1"
 
 debug@^2.1.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.1.tgz#79855090ba2c4e3115cc7d8769491d58f0491351"
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.3.tgz#0f7eb8c30965ec08c72accfa0130c8b79984141d"
   dependencies:
     ms "0.7.2"
 
@@ -204,6 +206,10 @@ diff@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf"
 
+diff@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
+
 djson@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/djson/-/djson-2.0.2.tgz#afd911a4c8e9ae43b95e7cd10b2c9f654ad7dd30"
@@ -211,70 +217,66 @@ djson@^2.0.2:
     lodash "^4.1.0"
     underscore.string "^3.2.3"
 
-doctrine@^1.2.2:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
+doctrine@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.0.0.tgz#c73d8d2909d22291e1a007a395804da8b665fe63"
   dependencies:
     esutils "^2.0.2"
     isarray "^1.0.0"
 
-es5-ext@^0.10.7, es5-ext@^0.10.8, es5-ext@~0.10.11, es5-ext@~0.10.2, es5-ext@~0.10.7:
-  version "0.10.12"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.12.tgz#aa84641d4db76b62abba5e45fd805ecbab140047"
+es5-ext@^0.10.14, es5-ext@^0.10.9, es5-ext@~0.10.14:
+  version "0.10.15"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.15.tgz#c330a5934c1ee21284a7c081a86e5fd937c91ea6"
   dependencies:
     es6-iterator "2"
     es6-symbol "~3.1"
 
-es6-iterator@2:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.0.tgz#bd968567d61635e33c0b80727613c9cb4b096bac"
+es6-iterator@2, es6-iterator@^2.0.1, es6-iterator@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.1.tgz#8e319c9f0453bf575d374940a655920e59ca5512"
   dependencies:
-    d "^0.1.1"
-    es5-ext "^0.10.7"
-    es6-symbol "3"
+    d "1"
+    es5-ext "^0.10.14"
+    es6-symbol "^3.1"
 
 es6-map@^0.1.3:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/es6-map/-/es6-map-0.1.4.tgz#a34b147be224773a4d7da8072794cefa3632b897"
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/es6-map/-/es6-map-0.1.5.tgz#9136e0503dcc06a301690f0bb14ff4e364e949f0"
   dependencies:
-    d "~0.1.1"
-    es5-ext "~0.10.11"
-    es6-iterator "2"
-    es6-set "~0.1.3"
-    es6-symbol "~3.1.0"
-    event-emitter "~0.3.4"
+    d "1"
+    es5-ext "~0.10.14"
+    es6-iterator "~2.0.1"
+    es6-set "~0.1.5"
+    es6-symbol "~3.1.1"
+    event-emitter "~0.3.5"
 
-es6-set@~0.1.3:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/es6-set/-/es6-set-0.1.4.tgz#9516b6761c2964b92ff479456233a247dc707ce8"
+es6-set@~0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/es6-set/-/es6-set-0.1.5.tgz#d2b3ec5d4d800ced818db538d28974db0a73ccb1"
   dependencies:
-    d "~0.1.1"
-    es5-ext "~0.10.11"
-    es6-iterator "2"
-    es6-symbol "3"
-    event-emitter "~0.3.4"
+    d "1"
+    es5-ext "~0.10.14"
+    es6-iterator "~2.0.1"
+    es6-symbol "3.1.1"
+    event-emitter "~0.3.5"
 
-es6-symbol@3, es6-symbol@~3.1, es6-symbol@~3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.0.tgz#94481c655e7a7cad82eba832d97d5433496d7ffa"
+es6-symbol@3.1.1, es6-symbol@^3.1, es6-symbol@^3.1.1, es6-symbol@~3.1, es6-symbol@~3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"
   dependencies:
-    d "~0.1.1"
-    es5-ext "~0.10.11"
+    d "1"
+    es5-ext "~0.10.14"
 
 es6-weak-map@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.1.tgz#0d2bbd8827eb5fb4ba8f97fbfea50d43db21ea81"
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.2.tgz#5e3ab32251ffd1538a1f8e5ffa1357772f92d96f"
   dependencies:
-    d "^0.1.1"
-    es5-ext "^0.10.8"
-    es6-iterator "2"
-    es6-symbol "3"
+    d "1"
+    es5-ext "^0.10.14"
+    es6-iterator "^2.0.1"
+    es6-symbol "^3.1.1"
 
-escape-string-regexp@1.0.2, escape-string-regexp@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz#4dbc2fe674e71949caf3fb2695ce7f2dc1d9a8d1"
-
-escape-string-regexp@^1.0.5:
+escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
@@ -291,17 +293,18 @@ eslint-config-mm@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/eslint-config-mm/-/eslint-config-mm-1.1.1.tgz#ab2ba90b5b6a88253a16b5f875204534f305fa37"
 
-eslint@^3.17.1:
-  version "3.17.1"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.17.1.tgz#b80ae12d9c406d858406fccda627afce33ea10ea"
+eslint@^3.19.0:
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.19.0.tgz#c8fc6201c7f40dd08941b87c085767386a679acc"
   dependencies:
     babel-code-frame "^6.16.0"
     chalk "^1.1.3"
-    concat-stream "^1.4.6"
+    concat-stream "^1.5.2"
     debug "^2.1.1"
-    doctrine "^1.2.2"
+    doctrine "^2.0.0"
     escope "^3.6.0"
     espree "^3.4.0"
+    esquery "^1.0.0"
     estraverse "^4.2.0"
     esutils "^2.0.2"
     file-entry-cache "^2.0.0"
@@ -331,15 +334,21 @@ eslint@^3.17.1:
     user-home "^2.0.0"
 
 espree@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-3.4.0.tgz#41656fa5628e042878025ef467e78f125cb86e1d"
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.4.1.tgz#28a83ab4aaed71ed8fe0f5efe61b76a05c13c4d2"
   dependencies:
-    acorn "4.0.4"
+    acorn "^5.0.1"
     acorn-jsx "^3.0.0"
 
 esprima@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
+
+esquery@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.0.tgz#cfba8b57d7fba93f17298a8a006a04cda13d80fa"
+  dependencies:
+    estraverse "^4.0.0"
 
 esrecurse@^4.1.0:
   version "4.1.0"
@@ -348,7 +357,7 @@ esrecurse@^4.1.0:
     estraverse "~4.1.0"
     object-assign "^4.0.1"
 
-estraverse@^4.1.1, estraverse@^4.2.0:
+estraverse@^4.0.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
@@ -360,12 +369,12 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
-event-emitter@~0.3.4:
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.4.tgz#8d63ddfb4cfe1fae3b32ca265c4c720222080bb5"
+event-emitter@~0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.5.tgz#df8c69eef1647923c7157b9ce83840610b02cc39"
   dependencies:
-    d "~0.1.1"
-    es5-ext "~0.10.7"
+    d "1"
+    es5-ext "~0.10.14"
 
 exit-hook@^1.0.0:
   version "1.1.1"
@@ -405,11 +414,11 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-formatio@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.1.1.tgz#5ed3ccd636551097383465d996199100e86161e9"
+formatio@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.2.0.tgz#f3b2167d9068c4698a8d51f4f760a39a54d818eb"
   dependencies:
-    samsam "~1.1"
+    samsam "1.x"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -425,12 +434,16 @@ generate-object-property@^1.1.0:
   dependencies:
     is-property "^1.0.0"
 
-glob@3.2.11:
-  version "3.2.11"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-3.2.11.tgz#4a973f635b9190f715d10987d5c00fd2815ebe3d"
+glob@7.0.5:
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.0.5.tgz#b4202a69099bbb4d292a7c1b95b6682b67ebdc95"
   dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
     inherits "2"
-    minimatch "0.3"
+    minimatch "^3.0.2"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
 
 glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
   version "7.1.1"
@@ -444,8 +457,8 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
     path-is-absolute "^1.0.0"
 
 globals@^9.14.0:
-  version "9.16.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-9.16.0.tgz#63e903658171ec2d9f51b1d31de5e2b8dc01fb80"
+  version "9.17.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-9.17.0.tgz#0c0ca696d9b9bb694d2e5470bd37777caad50286"
 
 globby@^5.0.0:
   version "5.0.0"
@@ -462,6 +475,10 @@ graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
+"graceful-readlink@>= 1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
+
 growl@1.9.2:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
@@ -472,9 +489,13 @@ has-ansi@^2.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
+has-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
+
 ignore@^3.2.0:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.2.4.tgz#4055e03596729a8fabe45a43c100ad5ed815c4e8"
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.2.6.tgz#26e8da0644be0bb4cb39516f6c79f0e0f4ffe48c"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -490,10 +511,6 @@ inflight@^1.0.4:
 inherits@2, inherits@^2.0.3, inherits@~2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
-
-inherits@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
 
 inquirer@^0.12.0:
   version "0.12.0"
@@ -514,8 +531,8 @@ inquirer@^0.12.0:
     through "^2.3.6"
 
 interpret@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.1.tgz#d579fb7f693b858004947af39fa0db49f795602c"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.2.tgz#f4f623f0bb7122f15f5717c8e254b8161b5c5b2d"
 
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"
@@ -566,24 +583,21 @@ is-resolvable@^1.0.0:
   dependencies:
     tryit "^1.0.1"
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+
 isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
-
-jade@0.26.3:
-  version "0.26.3"
-  resolved "https://registry.yarnpkg.com/jade/-/jade-0.26.3.tgz#8f10d7977d8d79f2f6ff862a81b0513ccb25686c"
-  dependencies:
-    commander "0.6.1"
-    mkdirp "0.3.0"
 
 js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
 js-yaml@^3.5.1:
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.2.tgz#02d3e2c0f6beab20248d412c352203827d786721"
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.3.tgz#33a05ec481c850c8875929166fe1beb61c728766"
   dependencies:
     argparse "^1.0.7"
     esprima "^3.1.1"
@@ -593,6 +607,10 @@ json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
   dependencies:
     jsonify "~0.0.0"
+
+json3@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
 
 jsonify@~0.0.0:
   version "0.0.0"
@@ -609,28 +627,64 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lodash@^4.0.0, lodash@^4.1.0, lodash@^4.3.0:
+lodash._baseassign@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz#8c38a099500f215ad09e59f1722fd0c52bfe0a4e"
+  dependencies:
+    lodash._basecopy "^3.0.0"
+    lodash.keys "^3.0.0"
+
+lodash._basecopy@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
+
+lodash._basecreate@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz#1bc661614daa7fc311b7d03bf16806a0213cf821"
+
+lodash._getnative@^3.0.0:
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
+
+lodash._isiterateecall@^3.0.0:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz#5203ad7ba425fae842460e696db9cf3e6aac057c"
+
+lodash.create@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.create/-/lodash.create-3.1.1.tgz#d7f2849f0dbda7e04682bb8cd72ab022461debe7"
+  dependencies:
+    lodash._baseassign "^3.0.0"
+    lodash._basecreate "^3.0.0"
+    lodash._isiterateecall "^3.0.0"
+
+lodash.isarguments@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
+
+lodash.isarray@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
+
+lodash.keys@^3.0.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a"
+  dependencies:
+    lodash._getnative "^3.0.0"
+    lodash.isarguments "^3.0.0"
+    lodash.isarray "^3.0.0"
+
+lodash@^4.0.0, lodash@^4.1.0, lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
-lolex@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.3.2.tgz#7c3da62ffcb30f0f5a80a2566ca24e45d8a01f31"
-
-lru-cache@2:
-  version "2.7.3"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.7.3.tgz#6d4524e8b955f95d4f5b58851ce21dd72fb4e952"
+lolex@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.6.0.tgz#3a9a0283452a47d7439e72731b9e07d7386e49f6"
 
 merge-descriptors@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
-
-minimatch@0.3:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-0.3.0.tgz#275d8edaac4f1bb3326472089e7949c8394699dd"
-  dependencies:
-    lru-cache "2"
-    sigmund "~1.0.0"
 
 minimatch@^3.0.2:
   version "3.0.3"
@@ -642,30 +696,27 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-mkdirp@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.3.0.tgz#1bbf5ab1ba827af23575143490426455f481fe1e"
-
 mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
 
-mocha@^2.0.1:
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-2.5.3.tgz#161be5bdeb496771eb9b35745050b622b5aefc58"
+mocha@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.2.0.tgz#7dc4f45e5088075171a68896814e6ae9eb7a85e3"
   dependencies:
-    commander "2.3.0"
+    browser-stdout "1.3.0"
+    commander "2.9.0"
     debug "2.2.0"
     diff "1.4.0"
-    escape-string-regexp "1.0.2"
-    glob "3.2.11"
+    escape-string-regexp "1.0.5"
+    glob "7.0.5"
     growl "1.9.2"
-    jade "0.26.3"
+    json3 "3.3.2"
+    lodash.create "3.1.1"
     mkdirp "0.5.1"
-    supports-color "1.2.0"
-    to-iso-string "0.0.2"
+    supports-color "3.1.2"
 
 module-not-found-error@^1.0.0:
   version "1.0.1"
@@ -682,6 +733,10 @@ ms@0.7.2:
 mute-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
+
+native-promise-only@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/native-promise-only/-/native-promise-only-0.8.1.tgz#20a318c30cb45f71fe7adfbf7b21c99c1472ef11"
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -728,6 +783,12 @@ path-is-inside@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
+
 pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -758,7 +819,7 @@ progress@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
 
-proxyquire@^1.0.1:
+proxyquire@^1.7.11:
   version "1.7.11"
   resolved "https://registry.yarnpkg.com/proxyquire/-/proxyquire-1.7.11.tgz#13b494eb1e71fb21cc3ebe3699e637d3bec1af9e"
   dependencies:
@@ -767,8 +828,8 @@ proxyquire@^1.0.1:
     resolve "~1.1.7"
 
 readable-stream@^2.2.2:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.3.tgz#9cf49463985df016c8ae8813097a9293a9b33729"
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.6.tgz#8b43aed76e71483938d12a8d46c6cf1a00b1f816"
   dependencies:
     buffer-shims "^1.0.0"
     core-util-is "~1.0.0"
@@ -830,34 +891,34 @@ rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
-samsam@1.1.2, samsam@~1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.2.tgz#bec11fdc83a9fda063401210e40176c3024d1567"
+samsam@1.x, samsam@^1.1.3:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.2.1.tgz#edd39093a3184370cb859243b2bdf255e7d8ea67"
 
 shelljs@^0.7.5:
-  version "0.7.6"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.6.tgz#379cccfb56b91c8601e4793356eb5382924de9ad"
+  version "0.7.7"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.7.tgz#b2f5c77ef97148f4b4f6e22682e10bba8667cff1"
   dependencies:
     glob "^7.0.0"
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-sigmund@~1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
+sinon-chai@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/sinon-chai/-/sinon-chai-2.9.0.tgz#34d820042bc9661a14527130d401eb462c49bb84"
 
-sinon-chai@^2.6.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/sinon-chai/-/sinon-chai-2.8.0.tgz#432a9bbfd51a6fc00798f4d2526a829c060687ac"
-
-sinon@^1.11.0:
-  version "1.17.7"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-1.17.7.tgz#4542a4f49ba0c45c05eb2e9dd9d203e2b8efe0bf"
+sinon@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-2.1.0.tgz#e057a9d2bf1b32f5d6dd62628ca9ee3961b0cafb"
   dependencies:
-    formatio "1.1.1"
-    lolex "1.3.2"
-    samsam "1.1.2"
-    util ">=0.10.3 <1"
+    diff "^3.1.0"
+    formatio "1.2.0"
+    lolex "^1.6.0"
+    native-promise-only "^0.8.1"
+    path-to-regexp "^1.7.0"
+    samsam "^1.1.3"
+    text-encoding "0.6.4"
+    type-detect "^4.0.0"
 
 slice-ansi@0.0.4:
   version "0.0.4"
@@ -900,9 +961,11 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-supports-color@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-1.2.0.tgz#ff1ed1e61169d06b3cf2d588e188b18d8847e17e"
+supports-color@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
+  dependencies:
+    has-flag "^1.0.0"
 
 supports-color@^2.0.0:
   version "2.0.0"
@@ -919,6 +982,10 @@ table@^3.7.8:
     slice-ansi "0.0.4"
     string-width "^2.0.0"
 
+text-encoding@0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
+
 text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -926,10 +993,6 @@ text-table@~0.2.0:
 through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
-
-to-iso-string@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/to-iso-string/-/to-iso-string-0.0.2.tgz#4dc19e664dfccbe25bd8db508b00c6da158255d1"
 
 traverse@^0.6.6:
   version "0.6.6"
@@ -953,6 +1016,10 @@ type-detect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
 
+type-detect@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.0.tgz#62053883542a321f2f7b25746dc696478b18ff6b"
+
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
@@ -973,12 +1040,6 @@ user-home@^2.0.0:
 util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-
-"util@>=0.10.3 <1":
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
-  dependencies:
-    inherits "2.0.1"
 
 wordwrap@~1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -478,12 +478,6 @@ has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
 
-highland@^2.10.5:
-  version "2.10.5"
-  resolved "https://registry.yarnpkg.com/highland/-/highland-2.10.5.tgz#6007fd24f4838d9117ba41bdcc98ec3b54bfde18"
-  dependencies:
-    util-deprecate "^1.0.2"
-
 ignore@^3.2.0:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.2.7.tgz#4810ca5f1d8eca5595213a34b94f2eb4ed926bbd"

--- a/yarn.lock
+++ b/yarn.lock
@@ -478,6 +478,12 @@ has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
 
+highland@^2.10.5:
+  version "2.10.5"
+  resolved "https://registry.yarnpkg.com/highland/-/highland-2.10.5.tgz#6007fd24f4838d9117ba41bdcc98ec3b54bfde18"
+  dependencies:
+    util-deprecate "^1.0.2"
+
 ignore@^3.2.0:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.2.7.tgz#4810ca5f1d8eca5595213a34b94f2eb4ed926bbd"


### PR DESCRIPTION
### Ticket
Link to ticket: https://enrise.atlassian.net/browse/TC-1020

### What has been done
- Only delete the `_strategy` directive after the merge has completed, not before it starts. This requires all strategy implementations to perform the delete action when they are done.
- Updated eslint rules

### How to test
- Failing unit test now succeeds
- Try with case discovered in ticket
